### PR TITLE
# Fix: Prevent Auto-Login After Signout by Implementing Complete Keycloak Logout

### DIFF
--- a/app/auth/create-account/page.tsx
+++ b/app/auth/create-account/page.tsx
@@ -14,7 +14,6 @@ import {
   Loader2,
   MailCheck,
 } from "lucide-react"
-import { signIn } from "next-auth/react"
 import { toast } from "sonner"
 import {
   createOrUpdateTrainingCenter,
@@ -48,6 +47,7 @@ import {
 } from "@/app/auth/create-account/_components/training-center-form"
 import { useAuthRealm } from "@/hooks/use-auth-realm"
 import { UserDomain } from "@/lib/types"
+import { signIn } from "@/services/auth"
 
 type AccountCreationStatus = "idle" | "submitting" | "success" | "error"
 

--- a/components/LoginButton.tsx
+++ b/components/LoginButton.tsx
@@ -1,8 +1,9 @@
 "use client"
 import React from "react"
 import { Button } from "./ui/button"
-import { signIn, useSession } from "next-auth/react"
 import { useRouter } from "next/navigation"
+import { useSession } from "next-auth/react"
+import { signIn } from "@/services/auth"
 
 export default function LoginButton() {
   const { data: session, status } = useSession()

--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -15,12 +15,12 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar"
-import { signOut } from "next-auth/react"
 import { useSession } from "next-auth/react"
 import { Badge } from "@/components/ui/badge"
 import { useRouter } from "next/navigation"
 import { MenuItem } from "@/lib/menu"
 import { useUserStore } from "@/store/use-user-store"
+import { signOut } from "@/services/auth"
 
 
 


### PR DESCRIPTION
## Bug Description
Users were automatically logged back in when clicking "Sign In" after signing out, without being prompted for credentials. This happened because NextAuth was only clearing its local JWT session but not terminating the underlying Keycloak SSO session.

## Root Cause
The NextAuth signout process was incomplete - it cleared the application session but left the Keycloak server session active, causing automatic re-authentication on subsequent login attempts.

## Fix
Added a `signOut` callback to the NextAuth configuration that properly terminates the Keycloak session by:
- Redirecting to Keycloak's logout endpoint
- Including required parameters (`post_logout_redirect_uri`, `client_id`)
- Using existing environment variables for configuration

## Changes Made
- ✅ Added `signOut` callback to NextAuth configuration
- ✅ Fixed TypeScript error by importing and using `JWT` type
- ✅ Added optional `signOut` event handler for debugging
- ✅ Used existing `AUTH_URL`, `KEYCLOAK_ISSUER`, and `KEYCLOAK_CLIENT_ID` environment variables

## Testing Checklist
- [ ] Sign out from application
- [ ] Verify no active session in Keycloak admin console
- [ ] Click "Sign In" - should prompt for credentials (not auto-login)
- [ ] Test across multiple browser tabs
- [ ] Verify logout redirect functions correctly

## Before/After
**Before:** Sign out → Click "Sign In" → Automatically redirected to dashboard  
**After:** Sign out → Click "Sign In" → Prompted for username/password

This ensures proper session management and gives users full control over their authentication state.