### PR TITLE
feat: Use GITHUB_PAT for Docker login in CI

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_PAT }}
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
This commit updates the `build-push.yaml` workflow to use `secrets.GITHUB_PAT` for logging into the GitHub Container Registry (GHCR). This aligns with the requirement to use a Personal Access Token for authentication during the Docker build process.