### PR TITLE
feat: add notification inbox UI and email templates

### DIFF
--- a/app/dashboard/_components/notifications/AlertsTab.tsx
+++ b/app/dashboard/_components/notifications/AlertsTab.tsx
@@ -1,130 +1,153 @@
 'use client';
 
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  useMarkAllNotificationsRead,
+  useNotificationAction,
+  useNotificationCounts,
+  useNotifications,
+  type NotificationListParams,
+  type UserNotification,
+} from '@/services/notifications';
+import { cn } from '@/lib/utils';
 import { formatDistanceToNow } from 'date-fns';
 import {
-  AlertCircle,
+  Archive,
+  Award,
   Bell,
-  Calendar,
+  CalendarClock,
   CheckCircle2,
-  Clock,
-  DollarSign,
-  FileText,
+  CreditCard,
+  ExternalLink,
+  FileCheck2,
+  GraduationCap,
+  Inbox,
   MessageSquare,
-  Trash2,
   UserPlus,
-  type LucideIcon
+  type LucideIcon,
 } from 'lucide-react';
+import Link from 'next/link';
 import { useState } from 'react';
 import { toast } from 'sonner';
-import { sampleAlertNotifications } from './data';
-import type {
-  AlertNotification,
-  AlertNotificationPriority,
-  AlertNotificationTab,
-  AlertNotificationType,
-} from './types';
 
-const notificationTabs: AlertNotificationTab[] = ['all', 'unread', 'messages', 'requests'];
+type NotificationTab = 'all' | 'unread' | 'popups' | 'archived';
 
-const isNotificationTab = (value: string): value is AlertNotificationTab =>
-  notificationTabs.includes(value as AlertNotificationTab);
+const notificationTabs: NotificationTab[] = ['all', 'unread', 'popups', 'archived'];
 
-function getNotificationIcon(type: AlertNotificationType) {
-  const iconMap: Record<AlertNotificationType, LucideIcon> = {
-    message: MessageSquare,
-    request: UserPlus,
-    enrollment: CheckCircle2,
-    payment: DollarSign,
-    class_update: Calendar,
-    review: FileText,
-    achievement: CheckCircle2,
-    reminder: Clock,
-    system: AlertCircle,
-  };
+const iconByType: Array<[RegExp, LucideIcon]> = [
+  [/PAYMENT|RECEIPT/, CreditCard],
+  [/CERTIFICATE|ACHIEVEMENT|MILESTONE/, Award],
+  [/CLASS|DEADLINE|REMINDER|SCHEDULE/, CalendarClock],
+  [/ENROLLMENT/, GraduationCap],
+  [/APPLICATION|INVITATION|REQUEST/, UserPlus],
+  [/DOCUMENT|PROFILE/, FileCheck2],
+  [/MESSAGE/, MessageSquare],
+];
 
-  return iconMap[type] || Bell;
+function isNotificationTab(value: string): value is NotificationTab {
+  return notificationTabs.includes(value as NotificationTab);
 }
 
-function getNotificationColor(type: AlertNotificationType) {
-  const colorMap: Record<AlertNotificationType, string> = {
-    message: 'text-primary',
-    request: 'text-accent-foreground',
-    enrollment: 'text-success',
-    payment: 'text-success',
-    class_update: 'text-orange-500',
-    review: 'text-yellow-500',
-    achievement: 'text-pink-500',
-    reminder: 'text-destructive',
-    system: 'text-muted-foreground',
-  };
-
-  return colorMap[type] || 'text-muted-foreground';
+function getNotificationIcon(type: string) {
+  return iconByType.find(([pattern]) => pattern.test(type))?.[1] ?? Bell;
 }
 
-function getPriorityBadgeVariant(priority: AlertNotificationPriority) {
-  const variantMap: Record<
-    AlertNotificationPriority,
-    'default' | 'destructive' | 'outline' | 'secondary'
-  > = {
-    low: 'outline',
-    medium: 'secondary',
-    high: 'default',
-    urgent: 'destructive',
-  };
+function getNotificationTone(notification: UserNotification) {
+  if (notification.status === 'UNREAD') {
+    return 'bg-primary/10 text-primary';
+  }
 
-  return variantMap[priority];
+  if (notification.presentation === 'POPUP') {
+    return 'bg-accent/15 text-accent-foreground';
+  }
+
+  return 'bg-muted text-muted-foreground';
+}
+
+function getQueryParams(tab: NotificationTab): NotificationListParams {
+  if (tab === 'unread') {
+    return { page: 0, size: 30, status: 'UNREAD' };
+  }
+
+  if (tab === 'popups') {
+    return { page: 0, size: 30, presentation: 'POPUP' };
+  }
+
+  if (tab === 'archived') {
+    return { page: 0, size: 30, status: 'ARCHIVED' };
+  }
+
+  return { page: 0, size: 30 };
+}
+
+function notificationTime(notification: UserNotification) {
+  const rawDate = notification.occurred_at ?? notification.created_at;
+  if (!rawDate) {
+    return 'Recently';
+  }
+
+  const date = new Date(rawDate);
+  if (Number.isNaN(date.getTime())) {
+    return 'Recently';
+  }
+
+  return formatDistanceToNow(date, { addSuffix: true });
+}
+
+function notificationTypeLabel(type: string) {
+  return type
+    .split('_')
+    .filter(Boolean)
+    .map(part => part.charAt(0) + part.slice(1).toLowerCase())
+    .join(' ');
 }
 
 export function AlertsTab() {
-  const [notifications, setNotifications] = useState<AlertNotification[]>(sampleAlertNotifications);
-  const [activeTab, setActiveTab] = useState<AlertNotificationTab>('all');
+  const [activeTab, setActiveTab] = useState<NotificationTab>('all');
+  const queryParams = getQueryParams(activeTab);
+  const notificationsQuery = useNotifications(queryParams);
+  const countsQuery = useNotificationCounts();
+  const actionMutation = useNotificationAction();
+  const markAllMutation = useMarkAllNotificationsRead();
 
-  const unreadCount = notifications.filter(notification => notification.status === 'unread').length;
-  const messageCount = notifications.filter(
-    notification => notification.type === 'message' && notification.status === 'unread'
-  ).length;
-  const requestCount = notifications.filter(
-    notification => notification.type === 'request' && notification.status === 'unread'
-  ).length;
+  const notifications = notificationsQuery.data?.items ?? [];
+  const unreadCount = countsQuery.data?.unread_count ?? 0;
+  const popupCount = countsQuery.data?.popup_count ?? 0;
+  const totalItems = notificationsQuery.data?.totalItems ?? notifications.length;
 
-  const filteredNotifications = notifications.filter(notification => {
-    if (activeTab === 'all') return true;
-    if (activeTab === 'unread') return notification.status === 'unread';
-    if (activeTab === 'messages') return notification.type === 'message';
-    if (activeTab === 'requests') return notification.type === 'request';
-    return true;
-  });
+  const handleMarkAsRead = (notification: UserNotification) => {
+    if (notification.status !== 'UNREAD') {
+      return;
+    }
 
-  const handleMarkAsRead = (id: string) => {
-    setNotifications(previous =>
-      previous.map(notification =>
-        notification.id === id ? { ...notification, status: 'read' } : notification
-      )
+    actionMutation.mutate(
+      { uuid: notification.uuid, action: 'read' },
+      {
+        onError: () => toast.error('Could not mark notification as read'),
+      }
+    );
+  };
+
+  const handleArchive = (notification: UserNotification) => {
+    actionMutation.mutate(
+      { uuid: notification.uuid, action: 'archive' },
+      {
+        onError: () => toast.error('Could not archive notification'),
+      }
     );
   };
 
   const handleMarkAllAsRead = () => {
-    setNotifications(previous =>
-      previous.map(notification => ({ ...notification, status: 'read' }))
-    );
-  };
-
-  const handleDelete = (id: string) => {
-    setNotifications(previous => previous.filter(notification => notification.id !== id));
-  };
-
-  const handleAction = (notificationId: string, actionType: string) => {
-    toast.message(`Action: ${actionType} on notification: ${notificationId}`);
-    handleMarkAsRead(notificationId);
+    markAllMutation.mutate(undefined, {
+      onError: () => toast.error('Could not mark notifications as read'),
+    });
   };
 
   return (
-    <section className="space-y-5 bg-background">
+    <section className='space-y-5 bg-background'>
       <Tabs
         value={activeTab}
         onValueChange={value => {
@@ -133,160 +156,185 @@ export function AlertsTab() {
           }
         }}
       >
-        <TabsList className='bg-muted/60 h-auto flex-wrap justify-start'>
-          <TabsTrigger value='all'>
-            All
-            {notifications.length > 0 ? (
-              <Badge variant='secondary' className='ml-2'>
-                {notifications.length}
-              </Badge>
-            ) : null}
-          </TabsTrigger>
-          <TabsTrigger value='unread'>
-            Unread
-            {unreadCount > 0 ? (
-              <Badge variant='destructive' className='ml-2'>
-                {unreadCount}
-              </Badge>
-            ) : null}
-          </TabsTrigger>
-          <TabsTrigger value='messages'>
-            Messages
-            {messageCount > 0 ? (
-              <Badge variant='secondary' className='ml-2'>
-                {messageCount}
-              </Badge>
-            ) : null}
-          </TabsTrigger>
-          <TabsTrigger value='requests'>
-            Requests
-            {requestCount > 0 ? (
-              <Badge variant='secondary' className='ml-2'>
-                {requestCount}
-              </Badge>
-            ) : null}
-          </TabsTrigger>
-        </TabsList>
+        <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+          <TabsList className='bg-muted/60 h-auto flex-wrap justify-start'>
+            <TabsTrigger value='all'>
+              <Inbox className='h-4 w-4' />
+              All
+              {totalItems > 0 ? (
+                <Badge variant='secondary' className='ml-2'>
+                  {totalItems}
+                </Badge>
+              ) : null}
+            </TabsTrigger>
+            <TabsTrigger value='unread'>
+              <Bell className='h-4 w-4' />
+              Unread
+              {unreadCount > 0 ? (
+                <Badge variant='destructive' className='ml-2'>
+                  {unreadCount}
+                </Badge>
+              ) : null}
+            </TabsTrigger>
+            <TabsTrigger value='popups'>
+              <ExternalLink className='h-4 w-4' />
+              Popups
+              {popupCount > 0 ? (
+                <Badge variant='secondary' className='ml-2'>
+                  {popupCount}
+                </Badge>
+              ) : null}
+            </TabsTrigger>
+            <TabsTrigger value='archived'>
+              <Archive className='h-4 w-4' />
+              Archived
+            </TabsTrigger>
+          </TabsList>
+
+          {unreadCount > 0 ? (
+            <Button
+              type='button'
+              variant='outline'
+              size='sm'
+              className='w-full justify-center rounded-md sm:w-auto'
+              disabled={markAllMutation.isPending}
+              onClick={handleMarkAllAsRead}
+            >
+              <CheckCircle2 className='h-4 w-4' />
+              Mark all read
+            </Button>
+          ) : null}
+        </div>
 
         <TabsContent value={activeTab} className='mt-5 mb-20'>
-          <div className='space-y-4'>
-            {filteredNotifications.length === 0 ? (
-              <Card className='p-8 sm:p-12'>
-                <div className='text-muted-foreground text-center'>
-                  <Bell className='mx-auto mb-4 h-10 w-10 sm:h-12 sm:w-12' />
-                  <p className='text-base font-medium sm:text-lg'>No notifications</p>
-                  <p className='text-xs sm:text-sm'>You're all caught up!</p>
-                </div>
-              </Card>
-            ) : (
-              filteredNotifications.map(notification => {
+          {notificationsQuery.isLoading ? (
+            <Card className='p-8 sm:p-12'>
+              <div className='flex flex-col items-center gap-3 text-muted-foreground'>
+                <div className='h-8 w-8 animate-spin rounded-full border-2 border-border border-t-primary' />
+                <p className='text-sm'>Loading notifications</p>
+              </div>
+            </Card>
+          ) : notificationsQuery.isError ? (
+            <Card className='p-8 sm:p-12'>
+              <div className='text-center text-muted-foreground'>
+                <Bell className='mx-auto mb-4 h-10 w-10 sm:h-12 sm:w-12' />
+                <p className='text-base font-medium text-foreground sm:text-lg'>
+                  Notifications could not be loaded
+                </p>
+                <p className='mt-1 text-xs sm:text-sm'>Refresh the page or try again shortly.</p>
+              </div>
+            </Card>
+          ) : notifications.length === 0 ? (
+            <Card className='p-8 sm:p-12'>
+              <div className='text-center text-muted-foreground'>
+                <Bell className='mx-auto mb-4 h-10 w-10 sm:h-12 sm:w-12' />
+                <p className='text-base font-medium text-foreground sm:text-lg'>No notifications</p>
+                <p className='mt-1 text-xs sm:text-sm'>You are all caught up.</p>
+              </div>
+            </Card>
+          ) : (
+            <div className='space-y-3'>
+              {notifications.map(notification => {
                 const Icon = getNotificationIcon(notification.type);
-                const iconColor = getNotificationColor(notification.type);
+                const unread = notification.status === 'UNREAD';
 
                 return (
                   <Card
-                    key={notification.id}
-                    className={`p-4 transition-colors ${notification.status === 'unread'
-                      ? 'bg-primary/5 border-l-primary border-l-4'
-                      : ''
-                      }`}
+                    key={notification.uuid}
+                    className={cn(
+                      'p-4 transition-colors',
+                      unread ? 'border-l-4 border-l-primary bg-primary/5' : 'bg-card'
+                    )}
                   >
                     <div className='flex gap-4'>
                       <div className='shrink-0'>
-                        {notification.sender ? (
-                          <Avatar>
-                            <AvatarImage src={notification.sender.avatar} />
-                            <AvatarFallback>
-                              {notification.sender.name
-                                .split(' ')
-                                .map(name => name[0])
-                                .join('')}
-                            </AvatarFallback>
-                          </Avatar>
-                        ) : (
-                          <div className='bg-muted flex h-10 w-10 items-center justify-center rounded-full'>
-                            <Icon className={`h-5 w-5 ${iconColor}`} />
-                          </div>
-                        )}
+                        <div
+                          className={cn(
+                            'flex h-10 w-10 items-center justify-center rounded-md',
+                            getNotificationTone(notification)
+                          )}
+                        >
+                          <Icon className='h-5 w-5' />
+                        </div>
                       </div>
 
                       <div className='min-w-0 flex-1'>
                         <div className='mb-1 flex flex-wrap items-start justify-between gap-2'>
-                          <div className='flex min-w-0 flex-wrap items-center gap-2'>
-                            <h3 className='text-sm font-semibold'>{notification.title}</h3>
-                            {notification.status === 'unread' ? (
-                              <div className='bg-primary h-2 w-2 rounded-full' />
-                            ) : null}
+                          <div className='min-w-0'>
+                            <div className='flex min-w-0 items-center gap-2'>
+                              <h3 className='truncate text-sm font-semibold'>
+                                {notification.title}
+                              </h3>
+                              {unread ? <div className='h-2 w-2 rounded-full bg-primary' /> : null}
+                            </div>
+                            <p className='mt-1 text-xs text-muted-foreground'>
+                              {notificationTypeLabel(notification.type)}
+                            </p>
                           </div>
+
                           <div className='flex items-center gap-2'>
-                            <Badge
-                              variant={getPriorityBadgeVariant(notification.priority)}
-                              className='text-xs'
-                            >
-                              {notification.priority}
+                            <Badge variant='outline' className='text-xs'>
+                              {notification.presentation}
                             </Badge>
                             <Button
+                              type='button'
                               variant='ghost'
-                              size='sm'
-                              onClick={() => handleDelete(notification.id)}
+                              size='icon'
+                              className='h-8 w-8'
+                              aria-label='Archive notification'
+                              disabled={actionMutation.isPending}
+                              onClick={() => handleArchive(notification)}
                             >
-                              <Trash2 className='h-4 w-4' />
+                              <Archive className='h-4 w-4' />
                             </Button>
                           </div>
                         </div>
 
-                        {notification.sender ? (
-                          <p className='text-muted-foreground mb-1 text-xs'>
-                            {notification.sender.name} - {notification.sender.role}
-                          </p>
-                        ) : null}
-
-                        <p className='text-muted-foreground mb-2 text-sm'>{notification.message}</p>
-
-                        {notification.metadata ? (
-                          <div className='mb-3 flex flex-wrap gap-2 text-xs'>
-                            {notification.metadata.courseName ? (
-                              <Badge variant='outline'>{notification.metadata.courseName}</Badge>
-                            ) : null}
-                            {notification.metadata.className ? (
-                              <Badge variant='outline'>{notification.metadata.className}</Badge>
-                            ) : null}
-                            {notification.metadata.amount ? (
-                              <Badge variant='outline' className='text-success'>
-                                ${notification.metadata.amount.toFixed(2)}
-                              </Badge>
-                            ) : null}
-                          </div>
-                        ) : null}
+                        <p className='mb-3 text-sm leading-6 text-muted-foreground'>
+                          {notification.body}
+                        </p>
 
                         <div className='flex flex-wrap items-center justify-between gap-2'>
-                          <p className='text-muted-foreground flex items-center gap-1 text-xs'>
-                            <Clock className='h-3 w-3' />
-                            {formatDistanceToNow(notification.timestamp, { addSuffix: true })}
+                          <p className='flex items-center gap-1 text-xs text-muted-foreground'>
+                            <CalendarClock className='h-3 w-3' />
+                            {notificationTime(notification)}
                           </p>
 
-                          {notification.actions ? (
-                            <div className='flex flex-wrap gap-2'>
-                              {notification.actions.map(action => (
-                                <Button
-                                  key={`${notification.id}-${action.type}`}
-                                  variant={action.variant || 'outline'}
-                                  size='sm'
-                                  onClick={() => handleAction(notification.id, action.type)}
-                                >
-                                  {action.label}
-                                </Button>
-                              ))}
-                            </div>
-                          ) : null}
+                          <div className='flex flex-wrap gap-2'>
+                            {unread ? (
+                              <Button
+                                type='button'
+                                variant='outline'
+                                size='sm'
+                                disabled={actionMutation.isPending}
+                                onClick={() => handleMarkAsRead(notification)}
+                              >
+                                <CheckCircle2 className='h-4 w-4' />
+                                Mark read
+                              </Button>
+                            ) : null}
+
+                            {notification.action_url ? (
+                              <Button
+                                asChild
+                                size='sm'
+                                onClick={() => handleMarkAsRead(notification)}
+                              >
+                                <Link href={notification.action_url}>
+                                  <ExternalLink className='h-4 w-4' />
+                                  Open
+                                </Link>
+                              </Button>
+                            ) : null}
+                          </div>
                         </div>
                       </div>
                     </div>
                   </Card>
                 );
-              })
-            )}
-          </div>
+              })}
+            </div>
+          )}
         </TabsContent>
       </Tabs>
     </section>

--- a/emails/components/ElimikaEmailLayout.tsx
+++ b/emails/components/ElimikaEmailLayout.tsx
@@ -1,0 +1,191 @@
+import * as React from 'react';
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Img,
+  Section,
+  Text,
+} from 'react-email';
+
+type ElimikaEmailLayoutProps = {
+  preview: string;
+  title: string;
+  eyebrow?: string;
+  children: React.ReactNode;
+};
+
+const supportEmailPlaceholder = '[[${supportEmail}]]';
+const currentYearPlaceholder = '[[${currentYear}]]';
+const companyNamePlaceholder = '[[${companyName}]]';
+
+const colors = {
+  background: '#f4f7fb',
+  card: '#ffffff',
+  ink: '#172033',
+  muted: '#5f6b7a',
+  border: '#dfe7f2',
+  blue: '#0061ed',
+  blueDark: '#0645b8',
+  green: '#00a86b',
+  footer: '#eef3f9',
+};
+
+export function ElimikaEmailLayout({
+  preview,
+  title,
+  eyebrow = 'Elimika notification',
+  children,
+}: ElimikaEmailLayoutProps) {
+  return (
+    <Html lang='en' {...({ 'xmlns:th': 'http://www.thymeleaf.org' } as Record<string, string>)}>
+      <Head>
+        <title>{preview}</title>
+      </Head>
+      <Body style={body}>
+        <Container style={container}>
+          <Section style={brandBar}>
+            <Img
+              src='cid:elimikaLogo'
+              alt='Elimika'
+              width='112'
+              height='112'
+              style={logo}
+            />
+            <Text style={brandKicker}>Powered by Sarafrika</Text>
+          </Section>
+
+          <Section style={hero}>
+            <Text style={eyebrowStyle}>{eyebrow}</Text>
+            <Heading as='h1' style={heading}>
+              {title}
+            </Heading>
+          </Section>
+
+          <Section style={content}>{children}</Section>
+
+          <Hr style={divider} />
+
+          <Section style={footer}>
+            <Text style={footerText}>
+              Need help? Contact{' '}
+              <a
+                href='mailto:[[${supportEmail}]]'
+                style={footerLink}
+                {...({ 'th:href': "${'mailto:' + supportEmail}" } as Record<string, string>)}
+              >
+                {supportEmailPlaceholder}
+              </a>
+              .
+            </Text>
+            <Text style={footerText}>
+              Copyright {currentYearPlaceholder} {companyNamePlaceholder}. All rights reserved.
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+const body = {
+  margin: '0',
+  backgroundColor: colors.background,
+  color: colors.ink,
+  fontFamily: 'Arial, Helvetica, sans-serif',
+};
+
+const container = {
+  width: '100%',
+  maxWidth: '640px',
+  margin: '0 auto',
+  padding: '32px 16px',
+};
+
+const brandBar = {
+  backgroundColor: colors.card,
+  borderTopLeftRadius: '8px',
+  borderTopRightRadius: '8px',
+  border: `1px solid ${colors.border}`,
+  borderBottom: '0',
+  padding: '24px 32px 18px',
+};
+
+const logo = {
+  display: 'block',
+  width: '112px',
+  height: '112px',
+  objectFit: 'contain',
+};
+
+const brandKicker = {
+  margin: '8px 0 0',
+  color: colors.muted,
+  fontSize: '12px',
+  lineHeight: '18px',
+  letterSpacing: '0',
+};
+
+const hero = {
+  backgroundColor: colors.blue,
+  backgroundImage: `linear-gradient(135deg, ${colors.blue} 0%, ${colors.blueDark} 100%)`,
+  padding: '30px 32px',
+};
+
+const eyebrowStyle = {
+  margin: '0 0 10px',
+  color: '#dbeafe',
+  fontSize: '12px',
+  lineHeight: '18px',
+  fontWeight: '700',
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0',
+};
+
+const heading = {
+  margin: '0',
+  color: '#ffffff',
+  fontSize: '28px',
+  lineHeight: '36px',
+  fontWeight: '700',
+  letterSpacing: '0',
+};
+
+const content = {
+  backgroundColor: colors.card,
+  borderLeft: `1px solid ${colors.border}`,
+  borderRight: `1px solid ${colors.border}`,
+  padding: '30px 32px 8px',
+};
+
+const divider = {
+  margin: '0',
+  borderColor: colors.border,
+  borderStyle: 'solid',
+  borderWidth: '1px 0 0',
+};
+
+const footer = {
+  backgroundColor: colors.footer,
+  borderBottomLeftRadius: '8px',
+  borderBottomRightRadius: '8px',
+  border: `1px solid ${colors.border}`,
+  borderTop: '0',
+  padding: '20px 32px 24px',
+};
+
+const footerText = {
+  margin: '0 0 8px',
+  color: colors.muted,
+  fontSize: '12px',
+  lineHeight: '18px',
+};
+
+const footerLink = {
+  color: colors.blue,
+  textDecoration: 'none',
+  fontWeight: '700',
+};

--- a/emails/export.tsx
+++ b/emails/export.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { access, mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { render, toPlainText } from 'react-email';
+import { AccountCreatedEmail } from './templates/AccountCreatedEmail';
+
+type EmailTemplateExport = {
+  filename: string;
+  component: React.ReactElement;
+};
+
+const templates: EmailTemplateExport[] = [
+  {
+    filename: 'account-created',
+    component: <AccountCreatedEmail />,
+  },
+];
+
+async function pathExists(candidate: string) {
+  try {
+    await access(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveBackendDir() {
+  const candidates = [
+    process.env.ELIMIKA_BACKEND_DIR,
+    path.resolve(process.cwd(), '../elimika'),
+    path.resolve(process.cwd(), '../../IdeaProjects/elimika'),
+  ].filter(Boolean) as string[];
+
+  for (const candidate of candidates) {
+    if (await pathExists(path.join(candidate, 'src/main/resources/templates/email'))) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    'Could not locate the Elimika backend. Set ELIMIKA_BACKEND_DIR to the backend checkout path.'
+  );
+}
+
+async function exportTemplates() {
+  const backendDir = await resolveBackendDir();
+  const templateDir = path.join(backendDir, 'src/main/resources/templates/email');
+  await mkdir(templateDir, { recursive: true });
+
+  for (const template of templates) {
+    const renderedHtml = await render(template.component, { pretty: true });
+    const html = renderedHtml.replaceAll('&#x27;', "'");
+    const text = toPlainText(html);
+
+    await writeFile(path.join(templateDir, `${template.filename}.html`), `${html}\n`, 'utf8');
+    await writeFile(path.join(templateDir, `${template.filename}.txt`), `${text}\n`, 'utf8');
+  }
+}
+
+exportTemplates().catch(error => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/emails/templates/AccountCreatedEmail.tsx
+++ b/emails/templates/AccountCreatedEmail.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { Button, Section, Text } from 'react-email';
+import { ElimikaEmailLayout } from '../components/ElimikaEmailLayout';
+
+const dashboardHref = '[[${frontendUrl}]]';
+const recipientNamePlaceholder = '[[${recipientName}]]';
+const createdAtPlaceholder = '[[${createdAt}]]';
+
+export function AccountCreatedEmail() {
+  return (
+    <ElimikaEmailLayout
+      preview='Your Elimika account has been created successfully.'
+      eyebrow='Account created'
+      title='Welcome to Elimika'
+    >
+      <Text style={paragraph}>Hello {recipientNamePlaceholder},</Text>
+
+      <Text style={paragraph}>
+        Your Elimika account has been created successfully. You can now sign in, complete your
+        profile, and continue with the learning or training workspace available to your account.
+      </Text>
+
+      <Section style={detailsPanel}>
+        <Text style={detailLabel}>Created on</Text>
+        <Text style={detailValue}>{createdAtPlaceholder} UTC</Text>
+      </Section>
+
+      <Button
+        href={dashboardHref}
+        style={primaryButton}
+        {...({ 'th:href': '${frontendUrl}' } as Record<string, string>)}
+      >
+        Open Elimika
+      </Button>
+
+      <Text style={securityNote}>
+        If you did not create this account, contact support immediately so the account can be
+        reviewed.
+      </Text>
+    </ElimikaEmailLayout>
+  );
+}
+
+export default AccountCreatedEmail;
+
+const paragraph = {
+  margin: '0 0 16px',
+  color: '#314155',
+  fontSize: '15px',
+  lineHeight: '24px',
+};
+
+const detailsPanel = {
+  margin: '22px 0',
+  padding: '16px 18px',
+  backgroundColor: '#f4f8ff',
+  border: '1px solid #dbe8ff',
+  borderRadius: '8px',
+};
+
+const detailLabel = {
+  margin: '0 0 4px',
+  color: '#5f6b7a',
+  fontSize: '12px',
+  lineHeight: '18px',
+  fontWeight: '700',
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0',
+};
+
+const detailValue = {
+  margin: '0',
+  color: '#172033',
+  fontSize: '15px',
+  lineHeight: '22px',
+  fontWeight: '700',
+};
+
+const primaryButton = {
+  display: 'inline-block',
+  margin: '8px 0 22px',
+  backgroundColor: '#0061ed',
+  borderRadius: '6px',
+  color: '#ffffff',
+  fontSize: '14px',
+  fontWeight: '700',
+  lineHeight: '20px',
+  padding: '13px 20px',
+  textDecoration: 'none',
+};
+
+const securityNote = {
+  margin: '2px 0 18px',
+  color: '#5f6b7a',
+  fontSize: '13px',
+  lineHeight: '20px',
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "openapi-ts": "openapi-ts && node post-generation-fix.mjs",
+    "emails:export": "tsx emails/export.tsx",
     "start": "next start",
     "lint": "biome lint . && node scripts/check-brand-colors.mjs",
     "lint:palette": "node scripts/check-brand-colors.mjs",
@@ -124,8 +125,10 @@
     "baseline-browser-mapping": "^2.8.32",
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.11",
+    "react-email": "^6.5.0",
     "sass": "^1.89.2",
     "tailwindcss": "^4",
+    "tsx": "^4.22.4",
     "typescript": "^5"
   },
   "packageManager": "pnpm@10.28.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,7 +165,7 @@ importers:
         version: 0.2.12
       '@udecode/plate-serializer-html':
         specifier: ^21.5.1
-        version: 21.5.1(@types/react@19.0.10)(jotai-optics@0.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-hyperscript@0.100.0(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)
+        version: 21.5.1(@babel/template@7.29.7)(@types/react@19.0.10)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.0.10)(react@19.2.1))(optics-ts@2.4.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-hyperscript@0.100.0(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)
       '@zodios/core':
         specifier: ^10.9.6
         version: 10.9.6(axios@1.15.2)(zod@3.25.76)
@@ -350,12 +350,18 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.6.11
         version: 0.6.11(prettier@3.5.3)
+      react-email:
+        specifier: ^6.5.0
+        version: 6.5.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       sass:
         specifier: ^1.89.2
         version: 1.89.2
       tailwindcss:
         specifier: ^4
         version: 4.0.9
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^5
         version: 5.8.2
@@ -380,8 +386,46 @@ packages:
       nodemailer:
         optional: true
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.27.0':
+    resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.27.0':
+    resolution: {integrity: sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@2.3.6':
@@ -406,24 +450,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.6':
     resolution: {integrity: sha512-JjYy83eVBnvuINZiqyFO7xx72v8Srh4hsgaacSBCjC22DwM6+ZvnX1/fj8/SBiLuUOfZ8YhU2pfq2Dzakeyg1A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.6':
     resolution: {integrity: sha512-QvxB8GHQeaO4FCtwJpJjCgJkbHBbWxRHUxQlod+xeaYE6gtJdSkYkuxdKAQUZEOIsec+PeaDAhW9xjzYbwmOFA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.6':
     resolution: {integrity: sha512-ZjPXzy5yN9wusIoX+8Zp4p6cL8r0NzJCXg/4r1KLVveIPXd2jKVlqZ6ZyzEq385WwU3OX5KOwQYLQsOc788waQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.6':
     resolution: {integrity: sha512-YM7hLHpwjdt8R7+O2zS1Vo2cKgqEeptiXB1tWW1rgjN5LlpZovBVKtg7zfwfRrFx3i08aNZThYpTcowpTlczug==}
@@ -464,6 +512,162 @@ packages:
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@floating-ui/core@0.7.3':
     resolution: {integrity: sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==}
@@ -570,89 +774,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -680,6 +900,19 @@ packages:
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
@@ -760,30 +993,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.82':
     resolution: {integrity: sha512-moZWuqepAwWBffdF4JDadt8TgBD02iMhG6I1FHZf8xO20AsIp9rB+p0B8Zma2h2vAF/YMjeFCDmW5un6+zZz9g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.82':
     resolution: {integrity: sha512-w9++2df2kG9eC9LWYIHIlMLuhIrKGQYfUxs97CwgxYjITeFakIRazI9LYWgVzEc98QZ9x9GQvlicFsrROV59MQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.82':
     resolution: {integrity: sha512-lZulOPwrRi6hEg/17CaqdwWEUfOlIJuhXxincx1aVzsVOCmyHf+xFq4i6liJl1P+x2v6Iz2Z/H5zHvXJCC7Bwg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.82':
     resolution: {integrity: sha512-Be9Wf5RTv1w6GXlTph55K3PH3vsAh1Ax4T1FQY1UYM0QfD0yrwGdnJ8/fhqw7dEgMjd59zIbjJQC8C3msbGn5g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-x64-msvc@0.1.82':
     resolution: {integrity: sha512-LN/i8VrvxTDmEEK1c10z2cdOTkWT76LlTGtyZe5Kr1sqoSomKeExAjbilnu1+oee5lZUgS5yfZ2LNlVhCeARuw==}
@@ -815,24 +1053,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.4':
     resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.4':
     resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.4':
     resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.4':
     resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
@@ -878,36 +1120,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -1842,6 +2090,13 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-email/render@2.0.8':
+    resolution: {integrity: sha512-5udvVr3U/WuGJZfLdLBOhkzrqRWd2Q5ZYmF7ppcy7FzWcwgshdqLMNqJOXcVzAXJXg/2bm7D+WGJzTtZOZMQnQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
   '@reduxjs/toolkit@2.8.2':
     resolution: {integrity: sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==}
     peerDependencies:
@@ -1860,6 +2115,12 @@ packages:
     resolution: {integrity: sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==}
     peerDependencies:
       react: '>=16.8.0'
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -1908,24 +2169,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.0.9':
     resolution: {integrity: sha512-3eMjyTC6HBxh9nRgOHzrc96PYh1/jWOwHZ3Kk0JN0Kl25BJ80Lj9HEvvwVDNTgPg154LdICwuFLuhfgH9DULmg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.0.9':
     resolution: {integrity: sha512-v0D8WqI/c3WpWH1kq/HP0J899ATLdGZmENa2/emmNjubT0sWtEke9W9+wXeEoACuGAhF9i3PO5MeyditpDCiWQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.0.9':
     resolution: {integrity: sha512-Kvp0TCkfeXyeehqLJr7otsc4hd/BUPfcIGrQiwsTVCfaMfjQZCG7DjI+9/QqPZha8YapLA9UoIcUILRYO7NE1Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-win32-arm64-msvc@4.0.9':
     resolution: {integrity: sha512-m3+60T/7YvWekajNq/eexjhV8z10rswcz4BC9bioJ7YaN+7K8W2AmLmG0B79H14m6UHE571qB0XsPus4n0QVgQ==}
@@ -2168,6 +2433,9 @@ packages:
   '@tiptap/starter-kit@3.0.7':
     resolution: {integrity: sha512-oTHZp6GXQQaZfZi8Fh7klH2YUeGq73XPF35CFw41mwdWdUUUms3ipaCKFqUyEYO21JMf3pZylJLxUucx5U7isg==}
 
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/d3-array@3.2.1':
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
 
@@ -2286,6 +2554,9 @@ packages:
   '@types/warning@3.0.3':
     resolution: {integrity: sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@udecode/plate-common@21.5.1':
     resolution: {integrity: sha512-ngjzC2/Rd+1OBGEb49Yds/XO1/j+IYs11sPxZ5v2Y6VsNPAbYG7GKhY6pIbmgDteYaKJJBA6fZwsz7KVIsngJA==}
     peerDependencies:
@@ -2379,6 +2650,10 @@ packages:
       '@zodios/core': ^10.x
       axios: ^0.x || ^1.0.0
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   acorn@8.14.0:
     resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
     engines: {node: '>=0.4.0'}
@@ -2387,6 +2662,12 @@ packages:
   adler-32@1.3.1:
     resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
     engines: {node: '>=0.8'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -2402,14 +2683,25 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  atomically@2.1.1:
+    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
+
   axios@1.15.2:
     resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   base64-js@1.3.1:
     resolution: {integrity: sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
 
   baseline-browser-mapping@2.10.16:
     resolution: {integrity: sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==}
@@ -2419,6 +2711,10 @@ packages:
   baseline-browser-mapping@2.8.32:
     resolution: {integrity: sha512-OPz5aBThlyLFgxyhdwf/s2+8ab3OvT7AdTNvKHBwpXomIYeXqpUUuT8LrdtxZSsWJ4R4CU1un4XGh5Ez3nlTpw==}
     hasBin: true
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2472,6 +2768,9 @@ packages:
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -2515,6 +2814,10 @@ packages:
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
 
+  conf@15.1.0:
+    resolution: {integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==}
+    engines: {node: '>=20'}
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -2522,8 +2825,16 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -2535,6 +2846,10 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   csscolorparser@1.0.3:
     resolution: {integrity: sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==}
@@ -2598,12 +2913,33 @@ packages:
   dayjs@1.11.19:
     resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
 
+  debounce-fn@6.0.0:
+    resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
+    engines: {node: '>=18'}
+
+  debounce@2.2.0:
+    resolution: {integrity: sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==}
+    engines: {node: '>=18'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   deep-equal@1.1.2:
     resolution: {integrity: sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==}
     engines: {node: '>= 0.4'}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
 
   default-browser-id@5.0.0:
     resolution: {integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==}
@@ -2664,6 +3000,23 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dot-prop@10.1.0:
+    resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
+    engines: {node: '>=20'}
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
@@ -2678,6 +3031,14 @@ packages:
   echarts@5.6.0:
     resolution: {integrity: sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==}
 
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
+  engine.io@6.6.8:
+    resolution: {integrity: sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==}
+    engines: {node: '>=10.2.0'}
+
   enhanced-resolve@5.18.1:
     resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
     engines: {node: '>=10.13.0'}
@@ -2685,6 +3046,10 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -2705,6 +3070,11 @@ packages:
   es-toolkit@1.39.5:
     resolution: {integrity: sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ==}
 
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -2714,6 +3084,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -2753,6 +3126,11 @@ packages:
       react-dom:
         optional: true
 
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -2781,8 +3159,16 @@ packages:
   gl-matrix@3.4.4:
     resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   globalize@0.1.1:
     resolution: {integrity: sha512-5e01v8eLGfuQSOvx2MsDMOWS0GFtCx1wPzQSmcHw4hkxFzrQDBO3Xwg/m8Hr/7qXMrHeOIE29qWVzyv06u1TZA==}
+
+  globals@11.12.0:
+    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
+    engines: {node: '>=4'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -2816,6 +3202,13 @@ packages:
 
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
+  html-to-text@9.0.5:
+    resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
+    engines: {node: '>=14'}
+
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -2883,6 +3276,10 @@ packages:
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
@@ -2978,6 +3375,22 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
@@ -2987,6 +3400,13 @@ packages:
 
   kdbush@4.0.2:
     resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
+  leac@0.6.0:
+    resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
@@ -3020,24 +3440,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.29.1:
     resolution: {integrity: sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.29.1:
     resolution: {integrity: sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.29.1:
     resolution: {integrity: sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.29.1:
     resolution: {integrity: sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==}
@@ -3073,9 +3497,17 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
 
   lucide-react@0.477.0:
     resolution: {integrity: sha512-yCf7aYxerFZAbd8jHJxjwe1j7jEMPptjnaOqdYeirFnEy85cNR3/L+o0I875CYFYya+eEVzZSbNuRk8BZPDpVw==}
@@ -3093,6 +3525,11 @@ packages:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
     hasBin: true
 
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   martinez-polygon-clipping@0.8.1:
     resolution: {integrity: sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==}
 
@@ -3102,6 +3539,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -3117,15 +3557,35 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@3.1.0:
@@ -3146,6 +3606,9 @@ packages:
 
   motion-utils@12.23.6:
     resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   murmurhash-js@1.0.0:
     resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
@@ -3168,6 +3631,10 @@ packages:
     resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
     engines: {node: ^18 || >=20}
     hasBin: true
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
@@ -3224,9 +3691,18 @@ packages:
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   nypm@0.5.4:
     resolution: {integrity: sha512-X0SNNrZiGU8/e/zAB7sCTtdxWTMSIO73q+xuKgglm2Yvzwlo8UoC5FNySQFCvl84uPaeADkqHUZUkWy4aH4xOA==}
     engines: {node: ^14.16.0 || >=16.10.0}
+    hasBin: true
+
+  nypm@0.6.6:
+    resolution: {integrity: sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==}
+    engines: {node: '>=18'}
     hasBin: true
 
   oauth4webapi@3.8.5:
@@ -3279,6 +3755,13 @@ packages:
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
+  parseley@0.12.1:
+    resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
@@ -3297,6 +3780,9 @@ packages:
     resolution: {integrity: sha512-bGbxbGFP5p8PWNT3Phsu1ZcRLnRfF6jmnuKTkgmt6i5PZzSdX6JaB+NeTz9q+aocfW8SE9GUjL3o/5GroBqGcQ==}
     engines: {node: '>=18'}
 
+  peberminta@0.9.0:
+    resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
+
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
@@ -3306,6 +3792,10 @@ packages:
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
+
+  picospinner@3.0.0:
+    resolution: {integrity: sha512-lGA1TNsmy2bxvRsTI2cV01kfTwKzZjnZSDmF9llYNyMHMrU4sP87lQ5taiIKm88L3cbswjl008nwyGc3WpNvzg==}
+    engines: {node: '>=18.0.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -3406,8 +3896,16 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -3524,6 +4022,14 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  react-email@6.5.0:
+    resolution: {integrity: sha512-WrJ+XPW87O1dabF4RJNGnTr7VTGsNa+BlMiinAZdH5fg8Kepwk++ZzX+LEieTlk+a3r13TaTJ4DfI9gv++y02g==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
 
   react-hook-form@7.54.2:
     resolution: {integrity: sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==}
@@ -3652,6 +4158,10 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
@@ -3687,6 +4197,9 @@ packages:
 
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
+
+  selderee@0.11.0:
+    resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
@@ -3729,6 +4242,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slate-dom@0.116.0:
     resolution: {integrity: sha512-ZyyPdT4zY4d/P/gfqMWBaAWWqV3N2BbAiDqEfOtZwPLcy7vvC02PsVvSZLaGun7DvaM2EIqdN7tTq3REbQkYgA==}
     peerDependencies:
@@ -3766,6 +4282,17 @@ packages:
   slate@0.117.2:
     resolution: {integrity: sha512-vHfMHrb8WJ6TFfl7yLXT+UlTzdbUQHpAfdGV0tJfECvbRMAOwAKkjgtAMI8FBmJ1t6BKUgX3ybXk3Y2JxQ2R1w==}
 
+  socket.io-adapter@2.5.7:
+    resolution: {integrity: sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==}
+
+  socket.io-parser@4.2.6:
+    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io@4.8.3:
+    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
+    engines: {node: '>=10.2.0'}
+
   sonner@2.0.1:
     resolution: {integrity: sha512-FRBphaehZ5tLdLcQ8g2WOIRE+Y7BCfWi5Zyd8bCvBjiW8TxxAyoWZIxS661Yz6TGPqFQ4VLzOF89WEYhfynSFQ==}
     peerDependencies:
@@ -3789,6 +4316,16 @@ packages:
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
+  stubborn-fs@2.0.0:
+    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
+
+  stubborn-utils@1.0.2:
+    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -3815,6 +4352,10 @@ packages:
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwind-merge@3.0.2:
     resolution: {integrity: sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==}
 
@@ -3830,6 +4371,9 @@ packages:
 
   tailwindcss@4.0.9:
     resolution: {integrity: sha512-12laZu+fv1ONDRoNR9ipTOpUD7RN9essRVkX36sjxuRUInpN7hIiHN4lBd/SIFjbISvnXzp8h/hXzmU8SQQYhw==}
+
+  tailwindcss@4.3.0:
+    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
@@ -3857,6 +4401,10 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyqueue@3.0.0:
     resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
@@ -3864,11 +4412,24 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
+
   tslib@2.3.0:
     resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  type-fest@5.7.0:
+    resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
+    engines: {node: '>=20'}
 
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
@@ -3885,6 +4446,10 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   uncontrollable@7.2.1:
     resolution: {integrity: sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==}
@@ -3956,6 +4521,10 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
@@ -3964,6 +4533,9 @@ packages:
 
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
+
+  when-exit@2.1.5:
+    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
 
   wmf@1.0.2:
     resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
@@ -3976,6 +4548,18 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xlsx@0.18.5:
     resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
     engines: {node: '>=0.8'}
@@ -3987,6 +4571,10 @@ packages:
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
   zod@3.25.76:
@@ -4039,7 +4627,56 @@ snapshots:
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/runtime@7.28.4': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.27.0':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.27.0
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@biomejs/biome@2.3.6':
     optionalDependencies:
@@ -4106,6 +4743,84 @@ snapshots:
   '@emnapi/runtime@1.8.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@floating-ui/core@0.7.3': {}
@@ -4312,6 +5027,20 @@ snapshots:
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.2
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jsdevtools/ono@7.1.3': {}
 
@@ -5422,6 +6151,13 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-email/render@2.0.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.5.3
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+
   '@reduxjs/toolkit@2.8.2(react-redux@9.2.0(@types/react@19.0.10)(react@19.2.1)(redux@5.0.1))(react@19.2.1)':
     dependencies:
       '@standard-schema/spec': 1.0.0
@@ -5440,6 +6176,13 @@ snapshots:
     dependencies:
       dequal: 2.0.3
       react: 19.2.1
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    dependencies:
+      domhandler: 5.0.3
+      selderee: 0.11.0
+
+  '@socket.io/component-emitter@3.1.2': {}
 
   '@standard-schema/spec@1.0.0': {}
 
@@ -5752,6 +6495,10 @@ snapshots:
       '@tiptap/extensions': 3.0.7(@tiptap/core@3.0.7(@tiptap/pm@3.0.7))(@tiptap/pm@3.0.7)
       '@tiptap/pm': 3.0.7
 
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 20.17.23
+
   '@types/d3-array@3.2.1': {}
 
   '@types/d3-color@3.1.3': {}
@@ -5873,10 +6620,14 @@ snapshots:
 
   '@types/warning@3.0.3': {}
 
-  '@udecode/plate-common@21.5.1(@types/react@19.0.10)(jotai-optics@0.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)':
+  '@types/ws@8.18.1':
     dependencies:
-      '@udecode/plate-core': 21.5.1(jotai-optics@0.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)
-      '@udecode/plate-utils': 21.5.1(@types/react@19.0.10)(jotai-optics@0.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)
+      '@types/node': 20.17.23
+
+  '@udecode/plate-common@21.5.1(@babel/template@7.29.7)(@types/react@19.0.10)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.0.10)(react@19.2.1))(optics-ts@2.4.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)':
+    dependencies:
+      '@udecode/plate-core': 21.5.1(@babel/template@7.29.7)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.0.10)(react@19.2.1))(optics-ts@2.4.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)
+      '@udecode/plate-utils': 21.5.1(@babel/template@7.29.7)(@types/react@19.0.10)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.0.10)(react@19.2.1))(optics-ts@2.4.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)
       '@udecode/slate': 21.4.1(slate-history@0.113.1(slate@0.117.2))(slate@0.117.2)
       '@udecode/slate-react': 21.4.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)
       '@udecode/slate-utils': 21.4.1(slate-history@0.113.1(slate@0.117.2))(slate@0.117.2)
@@ -5902,14 +6653,14 @@ snapshots:
       - react-native
       - scheduler
 
-  '@udecode/plate-core@21.5.1(jotai-optics@0.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)':
+  '@udecode/plate-core@21.5.1(@babel/template@7.29.7)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.0.10)(react@19.2.1))(optics-ts@2.4.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)':
     dependencies:
       '@udecode/slate': 21.4.1(slate-history@0.113.1(slate@0.117.2))(slate@0.117.2)
       '@udecode/slate-react': 21.4.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)
       '@udecode/utils': 19.7.1
       '@udecode/zustood': 1.1.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(zustand@3.7.2(react@19.2.1))
       clsx: 1.2.1
-      jotai: 1.13.1(jotai-optics@0.4.0)(react@19.2.1)
+      jotai: 1.13.1(@babel/template@7.29.7)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.0.10)(react@19.2.1))(optics-ts@2.4.1))(react@19.2.1)
       lodash: 4.18.1
       nanoid: 3.3.11
       react: 19.2.1
@@ -5935,9 +6686,9 @@ snapshots:
       - react-native
       - scheduler
 
-  '@udecode/plate-serializer-html@21.5.1(@types/react@19.0.10)(jotai-optics@0.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-hyperscript@0.100.0(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)':
+  '@udecode/plate-serializer-html@21.5.1(@babel/template@7.29.7)(@types/react@19.0.10)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.0.10)(react@19.2.1))(optics-ts@2.4.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-hyperscript@0.100.0(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)':
     dependencies:
-      '@udecode/plate-common': 21.5.1(@types/react@19.0.10)(jotai-optics@0.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)
+      '@udecode/plate-common': 21.5.1(@babel/template@7.29.7)(@types/react@19.0.10)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.0.10)(react@19.2.1))(optics-ts@2.4.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)
       html-entities: 2.6.0
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
@@ -5961,10 +6712,10 @@ snapshots:
       - react-native
       - scheduler
 
-  '@udecode/plate-utils@21.5.1(@types/react@19.0.10)(jotai-optics@0.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)':
+  '@udecode/plate-utils@21.5.1(@babel/template@7.29.7)(@types/react@19.0.10)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.0.10)(react@19.2.1))(optics-ts@2.4.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.0.10)(react@19.2.1)
-      '@udecode/plate-core': 21.5.1(jotai-optics@0.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)
+      '@udecode/plate-core': 21.5.1(@babel/template@7.29.7)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.0.10)(react@19.2.1))(optics-ts@2.4.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)
       '@udecode/slate': 21.4.1(slate-history@0.113.1(slate@0.117.2))(slate@0.117.2)
       '@udecode/slate-react': 21.4.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-history@0.113.1(slate@0.117.2))(slate-react@0.117.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.116.0(slate@0.117.2))(slate@0.117.2))(slate@0.117.2)
       '@udecode/slate-utils': 21.4.1(slate-history@0.113.1(slate@0.117.2))(slate@0.117.2)
@@ -6055,9 +6806,25 @@ snapshots:
       axios: 1.15.2
       qs: 6.14.2
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   acorn@8.14.0: {}
 
   adler-32@1.3.1: {}
+
+  ajv-formats@3.0.1:
+    dependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-colors@4.1.3: {}
 
@@ -6069,6 +6836,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  atomically@2.1.1:
+    dependencies:
+      stubborn-fs: 2.0.0
+      when-exit: 2.1.5
+
   axios@1.15.2:
     dependencies:
       follow-redirects: 1.16.0
@@ -6077,13 +6849,21 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  balanced-match@4.0.4: {}
+
   base64-js@1.3.1: {}
 
   base64-js@1.5.1: {}
 
+  base64id@2.0.0: {}
+
   baseline-browser-mapping@2.10.16: {}
 
   baseline-browser-mapping@2.8.32: {}
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -6149,6 +6929,8 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
+  citty@0.2.2: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -6185,17 +6967,41 @@ snapshots:
 
   compute-scroll-into-view@3.1.1: {}
 
+  conf@15.1.0:
+    dependencies:
+      ajv: 8.20.0
+      ajv-formats: 3.0.1
+      atomically: 2.1.1
+      debounce-fn: 6.0.0
+      dot-prop: 10.1.0
+      env-paths: 3.0.0
+      json-schema-typed: 8.0.2
+      semver: 7.7.4
+      uint8array-extras: 1.5.0
+
   confbox@0.1.8: {}
 
   consola@3.4.2: {}
 
+  cookie@0.7.2: {}
+
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   crc-32@1.2.2: {}
 
   crelt@1.0.6: {}
 
   crypto-js@4.2.0: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
 
   csscolorparser@1.0.3: {}
 
@@ -6247,6 +7053,16 @@ snapshots:
 
   dayjs@1.11.19: {}
 
+  debounce-fn@6.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  debounce@2.2.0: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decimal.js-light@2.5.1: {}
 
   deep-equal@1.1.2:
@@ -6257,6 +7073,8 @@ snapshots:
       object-is: 1.1.6
       object-keys: 1.1.1
       regexp.prototype.flags: 1.5.4
+
+  deepmerge@4.3.1: {}
 
   default-browser-id@5.0.0: {}
 
@@ -6307,6 +7125,28 @@ snapshots:
       '@babel/runtime': 7.28.4
       csstype: 3.1.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  dot-prop@10.1.0:
+    dependencies:
+      type-fest: 5.7.0
+
   dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
@@ -6322,12 +7162,33 @@ snapshots:
       tslib: 2.3.0
       zrender: 5.6.1
 
+  engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.8:
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 20.17.23
+      '@types/ws': 8.18.1
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   enhanced-resolve@5.18.1:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
 
   entities@4.5.0: {}
+
+  env-paths@3.0.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -6346,11 +7207,42 @@ snapshots:
 
   es-toolkit@1.39.5: {}
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escape-string-regexp@4.0.0: {}
 
   eventemitter3@5.0.1: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.2: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -6381,6 +7273,9 @@ snapshots:
     optionalDependencies:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -6420,7 +7315,15 @@ snapshots:
 
   gl-matrix@3.4.4: {}
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   globalize@0.1.1: {}
+
+  globals@11.12.0: {}
 
   gopd@1.2.0: {}
 
@@ -6452,6 +7355,21 @@ snapshots:
       function-bind: 1.1.2
 
   html-entities@2.6.0: {}
+
+  html-to-text@9.0.5:
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.11.0
+      deepmerge: 4.3.1
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
 
   iconv-lite@0.6.3:
     dependencies:
@@ -6511,6 +7429,8 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
+  is-unicode-supported@2.1.0: {}
+
   is-wsl@3.1.0:
     dependencies:
       is-inside-container: 1.0.0
@@ -6533,10 +7453,11 @@ snapshots:
       '@types/react': 19.0.10
       react: 19.2.1
 
-  jotai@1.13.1(jotai-optics@0.4.0)(react@19.2.1):
+  jotai@1.13.1(@babel/template@7.29.7)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.0.10)(react@19.2.1))(optics-ts@2.4.1))(react@19.2.1):
     dependencies:
       react: 19.2.1
     optionalDependencies:
+      '@babel/template': 7.29.7
       jotai-optics: 0.4.0(jotai@2.8.4(@types/react@19.0.10)(react@19.2.1))(optics-ts@2.4.1)
 
   jotai@2.8.4(@types/react@19.0.10)(react@19.2.1):
@@ -6552,6 +7473,14 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsesc@3.1.0: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
+  json5@2.2.3: {}
+
   jszip@3.10.1:
     dependencies:
       lie: 3.3.0
@@ -6562,6 +7491,10 @@ snapshots:
   jwt-decode@4.0.0: {}
 
   kdbush@4.0.2: {}
+
+  kleur@3.0.3: {}
+
+  leac@0.6.0: {}
 
   lie@3.3.0:
     dependencies:
@@ -6626,9 +7559,16 @@ snapshots:
 
   lodash@4.18.1: {}
 
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lru-cache@11.5.1: {}
 
   lucide-react@0.477.0(react@19.2.1):
     dependencies:
@@ -6674,6 +7614,8 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
+  marked@15.0.12: {}
+
   martinez-polygon-clipping@0.8.1:
     dependencies:
       robust-predicates: 2.0.4
@@ -6683,6 +7625,8 @@ snapshots:
   material-colors@1.2.6: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
 
@@ -6696,13 +7640,27 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
 
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  mimic-function@5.0.1: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
 
   minizlib@3.1.0:
     dependencies:
@@ -6727,6 +7685,8 @@ snapshots:
 
   motion-utils@12.23.6: {}
 
+  ms@2.1.3: {}
+
   murmurhash-js@1.0.0: {}
 
   mutative@1.1.0: {}
@@ -6736,6 +7696,8 @@ snapshots:
   nanoid@3.3.8: {}
 
   nanoid@5.1.5: {}
+
+  negotiator@0.6.3: {}
 
   neo-async@2.6.2: {}
 
@@ -6782,6 +7744,8 @@ snapshots:
 
   node-fetch-native@1.6.7: {}
 
+  normalize-path@3.0.0: {}
+
   nypm@0.5.4:
     dependencies:
       citty: 0.1.6
@@ -6790,6 +7754,12 @@ snapshots:
       pkg-types: 1.3.1
       tinyexec: 0.3.2
       ufo: 1.6.1
+
+  nypm@0.6.6:
+    dependencies:
+      citty: 0.2.2
+      pathe: 2.0.3
+      tinyexec: 1.2.4
 
   oauth4webapi@3.8.5: {}
 
@@ -6833,6 +7803,16 @@ snapshots:
 
   pako@1.0.11: {}
 
+  parseley@0.12.1:
+    dependencies:
+      leac: 0.6.0
+      peberminta: 0.9.0
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
+      minipass: 7.1.3
+
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
@@ -6852,12 +7832,16 @@ snapshots:
       iconv-lite: 0.6.3
       xmldoc: 2.0.2
 
+  peberminta@0.9.0: {}
+
   perfect-debounce@1.0.0: {}
 
   picocolors@1.1.1: {}
 
   picomatch@2.3.2:
     optional: true
+
+  picospinner@3.0.0: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -6922,7 +7906,14 @@ snapshots:
 
   prettier@3.5.3: {}
 
+  prismjs@1.30.0: {}
+
   process-nextick-args@2.0.1: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   prop-types@15.8.1:
     dependencies:
@@ -7103,6 +8094,37 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 
+  react-email@6.5.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@babel/traverse': 7.27.0
+      '@react-email/render': 2.0.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      chokidar: 4.0.3
+      commander: 13.0.0
+      conf: 15.1.0
+      css-tree: 3.2.1
+      debounce: 2.2.0
+      esbuild: 0.28.0
+      glob: 13.0.6
+      jiti: 2.4.2
+      log-symbols: 7.0.1
+      marked: 15.0.12
+      mime-types: 3.0.2
+      normalize-path: 3.0.0
+      nypm: 0.6.6
+      picospinner: 3.0.0
+      prismjs: 1.30.0
+      prompts: 2.4.2
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      socket.io: 4.8.3
+      tailwindcss: 4.3.0
+      tsconfig-paths: 4.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   react-hook-form@7.54.2(react@19.2.1):
     dependencies:
       react: 19.2.1
@@ -7240,6 +8262,8 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  require-from-string@2.0.2: {}
+
   reselect@5.1.1: {}
 
   resolve-protobuf-schema@2.1.0:
@@ -7272,10 +8296,13 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
+  selderee@0.11.0:
+    dependencies:
+      parseley: 0.12.1
+
   semver@7.7.2: {}
 
-  semver@7.7.4:
-    optional: true
+  semver@7.7.4: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -7355,6 +8382,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  sisteransi@1.0.5: {}
+
   slate-dom@0.116.0(slate@0.117.0):
     dependencies:
       '@juggle/resize-observer': 3.4.0
@@ -7423,6 +8452,36 @@ snapshots:
       immer: 10.1.1
       tiny-warning: 1.0.3
 
+  socket.io-adapter@2.5.7:
+    dependencies:
+      debug: 4.4.3
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  socket.io@4.8.3:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io: 6.6.8
+      socket.io-adapter: 2.5.7
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   sonner@2.0.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       react: 19.2.1
@@ -7442,6 +8501,14 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
+  strip-bom@3.0.0: {}
+
+  stubborn-fs@2.0.0:
+    dependencies:
+      stubborn-utils: 1.0.2
+
+  stubborn-utils@1.0.2: {}
+
   styled-jsx@5.1.6(react@19.2.1):
     dependencies:
       client-only: 0.0.1
@@ -7457,6 +8524,8 @@ snapshots:
 
   tabbable@6.2.0: {}
 
+  tagged-tag@1.0.0: {}
+
   tailwind-merge@3.0.2: {}
 
   tailwind-scrollbar-hide@4.0.0(tailwindcss@4.0.9):
@@ -7468,6 +8537,8 @@ snapshots:
       tailwindcss: 4.0.9
 
   tailwindcss@4.0.9: {}
+
+  tailwindcss@4.3.0: {}
 
   tapable@2.2.1: {}
 
@@ -7491,6 +8562,8 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
+  tinyexec@1.2.4: {}
+
   tinyqueue@3.0.0: {}
 
   to-regex-range@5.0.1:
@@ -7498,9 +8571,25 @@ snapshots:
       is-number: 7.0.0
     optional: true
 
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
   tslib@2.3.0: {}
 
   tslib@2.8.1: {}
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  type-fest@5.7.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typescript@5.8.2: {}
 
@@ -7510,6 +8599,8 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
+
+  uint8array-extras@1.5.0: {}
 
   uncontrollable@7.2.1(react@19.2.1):
     dependencies:
@@ -7570,6 +8661,8 @@ snapshots:
 
   uuid@10.0.0: {}
 
+  vary@1.1.2: {}
+
   victory-vendor@37.3.6:
     dependencies:
       '@types/d3-array': 3.2.1
@@ -7593,11 +8686,15 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  when-exit@2.1.5: {}
+
   wmf@1.0.2: {}
 
   word@0.3.0: {}
 
   wordwrap@1.0.0: {}
+
+  ws@8.20.1: {}
 
   xlsx@0.18.5:
     dependencies:
@@ -7614,6 +8711,8 @@ snapshots:
       sax: 1.4.1
 
   yallist@5.0.0: {}
+
+  yoctocolors@2.1.2: {}
 
   zod@3.25.76: {}
 

--- a/services/notifications.ts
+++ b/services/notifications.ts
@@ -1,0 +1,241 @@
+import { toNumber } from '@/lib/metrics';
+import { fetchClient } from '@/services/api/fetch-client';
+import { useMutation, useQuery, useQueryClient, type UseQueryOptions } from '@tanstack/react-query';
+import { z } from 'zod';
+
+const notificationSchema = z.object({
+  uuid: z.string().uuid(),
+  notification_id: z.string().uuid().optional(),
+  type: z.string(),
+  category: z.string().optional(),
+  priority: z.string().default('NORMAL'),
+  presentation: z.string().default('INBOX'),
+  status: z.string().default('UNREAD'),
+  title: z.string(),
+  body: z.string(),
+  action_url: z.string().nullable().optional(),
+  metadata: z.record(z.unknown()).optional().default({}),
+  occurred_at: z.string().optional(),
+  popup_seen_at: z.string().nullable().optional(),
+  read_at: z.string().nullable().optional(),
+  archived_at: z.string().nullable().optional(),
+  created_at: z.string().optional(),
+});
+
+const notificationsResponseSchema = z.object({
+  success: z.boolean().optional(),
+  message: z.string().optional(),
+  data: z
+    .object({
+      content: z.array(notificationSchema).default([]),
+      metadata: z
+        .object({
+          pageNumber: z.number().int().optional(),
+          pageSize: z.number().int().optional(),
+          totalElements: z.coerce.bigint().optional(),
+          totalPages: z.number().int().optional(),
+          hasNext: z.boolean().optional(),
+          hasPrevious: z.boolean().optional(),
+        })
+        .partial()
+        .optional(),
+    })
+    .optional(),
+});
+
+const notificationCountsResponseSchema = z.object({
+  success: z.boolean().optional(),
+  message: z.string().optional(),
+  data: z
+    .object({
+      unread_count: z.number().int().default(0),
+      popup_count: z.number().int().default(0),
+    })
+    .default({ unread_count: 0, popup_count: 0 }),
+});
+
+const notificationActionResponseSchema = z.object({
+  success: z.boolean().optional(),
+  message: z.string().optional(),
+  data: z.unknown().optional(),
+});
+
+export type UserNotification = z.infer<typeof notificationSchema>;
+
+export interface NotificationListParams {
+  page?: number;
+  size?: number;
+  status?: 'UNREAD' | 'READ' | 'ARCHIVED';
+  presentation?: 'POPUP' | 'INBOX';
+  type?: string;
+  popupSeen?: boolean;
+}
+
+export interface NotificationListResult {
+  items: UserNotification[];
+  page: number;
+  size: number;
+  totalItems: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrevious: boolean;
+}
+
+export interface NotificationCounts {
+  unread_count: number;
+  popup_count: number;
+}
+
+const defaultListParams = {
+  page: 0,
+  size: 20,
+} satisfies NotificationListParams;
+
+export const notificationListQueryKey = (params: NotificationListParams = {}) =>
+  ['notifications', 'list', normalizeListParams(params)] as const;
+
+export const notificationCountsQueryKey = ['notifications', 'counts'] as const;
+
+function normalizeListParams(params: NotificationListParams = {}): NotificationListParams {
+  return {
+    ...defaultListParams,
+    ...params,
+  };
+}
+
+export async function fetchNotifications(
+  params: NotificationListParams = {}
+): Promise<NotificationListResult> {
+  const normalizedParams = normalizeListParams(params);
+
+  const response = await fetchClient.GET('/api/v1/notifications' as never, {
+    params: {
+      query: {
+        page: normalizedParams.page,
+        size: normalizedParams.size,
+        sort: 'createdDate,desc',
+        status: normalizedParams.status,
+        presentation: normalizedParams.presentation,
+        type: normalizedParams.type,
+        popup_seen: normalizedParams.popupSeen,
+      },
+    },
+  } as never);
+
+  if (response.error) {
+    throw new Error(
+      typeof response.error === 'string' ? response.error : 'Failed to fetch notifications'
+    );
+  }
+
+  const parsed = notificationsResponseSchema.parse(response.data ?? {});
+  const items = parsed.data?.content ?? [];
+  const metadata = parsed.data?.metadata ?? {};
+  const page = metadata.pageNumber ?? normalizedParams.page ?? 0;
+  const size = metadata.pageSize ?? normalizedParams.size ?? 20;
+  const totalItems = toNumber(metadata.totalElements);
+  const totalPages = metadata.totalPages ?? (totalItems > 0 ? Math.ceil(totalItems / size) : 0);
+
+  return {
+    items,
+    page,
+    size,
+    totalItems,
+    totalPages,
+    hasNext: metadata.hasNext ?? page < totalPages - 1,
+    hasPrevious: metadata.hasPrevious ?? page > 0,
+  };
+}
+
+export async function fetchNotificationCounts(): Promise<NotificationCounts> {
+  const response = await fetchClient.GET('/api/v1/notifications/counts' as never);
+
+  if (response.error) {
+    throw new Error(
+      typeof response.error === 'string' ? response.error : 'Failed to fetch notification counts'
+    );
+  }
+
+  return notificationCountsResponseSchema.parse(response.data ?? {}).data;
+}
+
+async function applyNotificationAction(uuid: string, action: 'read' | 'archive' | 'popup_seen') {
+  const response = await fetchClient.POST('/api/v1/notifications/{uuid}' as never, {
+    params: {
+      path: { uuid },
+      query: { action },
+    },
+  } as never);
+
+  if (response.error) {
+    throw new Error(
+      typeof response.error === 'string' ? response.error : 'Failed to update notification'
+    );
+  }
+
+  return notificationActionResponseSchema.parse(response.data ?? {});
+}
+
+async function markAllNotificationsRead() {
+  const response = await fetchClient.POST('/api/v1/notifications' as never, {
+    params: {
+      query: { action: 'read_all' },
+    },
+  } as never);
+
+  if (response.error) {
+    throw new Error(
+      typeof response.error === 'string' ? response.error : 'Failed to mark notifications read'
+    );
+  }
+
+  return notificationActionResponseSchema.parse(response.data ?? {});
+}
+
+export function useNotifications(
+  params: NotificationListParams,
+  options?: Partial<UseQueryOptions<NotificationListResult, Error>>
+) {
+  const normalizedParams = normalizeListParams(params);
+
+  return useQuery({
+    queryKey: notificationListQueryKey(normalizedParams),
+    queryFn: () => fetchNotifications(normalizedParams),
+    refetchInterval: 30_000,
+    ...options,
+  });
+}
+
+export function useNotificationCounts(
+  options?: Partial<UseQueryOptions<NotificationCounts, Error>>
+) {
+  return useQuery({
+    queryKey: notificationCountsQueryKey,
+    queryFn: fetchNotificationCounts,
+    refetchInterval: 30_000,
+    ...options,
+  });
+}
+
+export function useNotificationAction() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ uuid, action }: { uuid: string; action: 'read' | 'archive' | 'popup_seen' }) =>
+      applyNotificationAction(uuid, action),
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['notifications'] });
+    },
+  });
+}
+
+export function useMarkAllNotificationsRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: markAllNotificationsRead,
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['notifications'] });
+    },
+  });
+}

--- a/src/features/dashboard/components/dashboard-notifications.tsx
+++ b/src/features/dashboard/components/dashboard-notifications.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  useMarkAllNotificationsRead,
+  useNotificationAction,
+  useNotificationCounts,
+  useNotifications,
+  type UserNotification,
+} from '@/services/notifications';
+import { cn } from '@/lib/utils';
+import { formatDistanceToNow } from 'date-fns';
+import {
+  Award,
+  Bell,
+  CalendarClock,
+  CheckCircle2,
+  CreditCard,
+  FileCheck2,
+  GraduationCap,
+  MessageSquare,
+  UserPlus,
+  type LucideIcon,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+
+type DashboardNotificationsProps = {
+  notificationHref: string;
+};
+
+const iconByType: Array<[RegExp, LucideIcon]> = [
+  [/PAYMENT|RECEIPT/, CreditCard],
+  [/CERTIFICATE|ACHIEVEMENT|MILESTONE/, Award],
+  [/CLASS|DEADLINE|REMINDER|SCHEDULE/, CalendarClock],
+  [/ENROLLMENT/, GraduationCap],
+  [/APPLICATION|INVITATION|REQUEST/, UserPlus],
+  [/DOCUMENT|PROFILE/, FileCheck2],
+  [/MESSAGE/, MessageSquare],
+];
+
+function notificationIcon(type: string) {
+  return iconByType.find(([pattern]) => pattern.test(type))?.[1] ?? Bell;
+}
+
+function notificationTime(notification: UserNotification) {
+  const rawDate = notification.occurred_at ?? notification.created_at;
+  if (!rawDate) {
+    return '';
+  }
+
+  const date = new Date(rawDate);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  return formatDistanceToNow(date, { addSuffix: true });
+}
+
+function NotificationRow({
+  notification,
+  onRead,
+}: {
+  notification: UserNotification;
+  onRead: (notification: UserNotification) => void;
+}) {
+  const Icon = notificationIcon(notification.type);
+  const unread = notification.status === 'UNREAD';
+  const href = notification.action_url || '#';
+
+  return (
+    <Link
+      href={href}
+      onClick={() => onRead(notification)}
+      className='hover:bg-muted/60 focus-visible:ring-ring block rounded-md px-3 py-3 outline-none transition focus-visible:ring-2'
+    >
+      <div className='flex gap-3'>
+        <div
+          className={cn(
+            'flex h-9 w-9 shrink-0 items-center justify-center rounded-md',
+            unread ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground'
+          )}
+        >
+          <Icon className='h-4 w-4' />
+        </div>
+
+        <div className='min-w-0 flex-1'>
+          <div className='flex items-start gap-2'>
+            <p className='text-foreground line-clamp-1 text-sm font-semibold'>
+              {notification.title}
+            </p>
+            {unread ? <span className='bg-primary mt-1.5 h-2 w-2 shrink-0 rounded-full' /> : null}
+          </div>
+          <p className='text-muted-foreground mt-1 line-clamp-2 text-xs leading-5'>
+            {notification.body}
+          </p>
+          <p className='text-muted-foreground mt-2 text-[11px]'>{notificationTime(notification)}</p>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+export function DashboardNotifications({ notificationHref }: DashboardNotificationsProps) {
+  const shownPopupIds = useRef<Set<string>>(new Set());
+  const actionMutation = useNotificationAction();
+  const markAllMutation = useMarkAllNotificationsRead();
+
+  const countsQuery = useNotificationCounts();
+  const recentQuery = useNotifications({ page: 0, size: 6 });
+  const popupQuery = useNotifications({
+    page: 0,
+    size: 5,
+    presentation: 'POPUP',
+    popupSeen: false,
+  });
+
+  const unreadCount = countsQuery.data?.unread_count ?? 0;
+  const recentNotifications = recentQuery.data?.items ?? [];
+  const popupNotifications = popupQuery.data?.items ?? [];
+
+  useEffect(() => {
+    for (const notification of popupNotifications) {
+      if (shownPopupIds.current.has(notification.uuid)) {
+        continue;
+      }
+
+      shownPopupIds.current.add(notification.uuid);
+      toast(notification.title, {
+        description: notification.body,
+        action: notification.action_url
+          ? {
+              label: 'Open',
+              onClick: () => {
+                window.location.href = notification.action_url || notificationHref;
+              },
+            }
+          : undefined,
+      });
+      actionMutation.mutate({ uuid: notification.uuid, action: 'popup_seen' });
+    }
+  }, [actionMutation, notificationHref, popupNotifications]);
+
+  const handleRead = (notification: UserNotification) => {
+    if (notification.status === 'UNREAD') {
+      actionMutation.mutate({ uuid: notification.uuid, action: 'read' });
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant='outline'
+          size='icon'
+          className='border-border/70 bg-card/80 relative h-10 w-10 rounded-md shadow-sm'
+          aria-label='Notifications'
+        >
+          <Bell className='h-4 w-4' />
+          {unreadCount > 0 ? (
+            <span className='bg-destructive text-destructive-foreground absolute -top-1 -right-1 flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-[10px] font-semibold'>
+              {unreadCount > 99 ? '99+' : unreadCount}
+            </span>
+          ) : null}
+        </Button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align='end' className='w-[min(92vw,380px)] p-0'>
+        <div className='flex items-center justify-between px-4 py-3'>
+          <DropdownMenuLabel className='p-0 text-sm font-semibold'>Notifications</DropdownMenuLabel>
+          <div className='flex items-center gap-2'>
+            {unreadCount > 0 ? (
+              <Button
+                variant='ghost'
+                size='sm'
+                className='h-8 px-2 text-xs'
+                onClick={() => markAllMutation.mutate()}
+              >
+                <CheckCircle2 className='h-3.5 w-3.5' />
+                Mark read
+              </Button>
+            ) : null}
+            <Badge variant='secondary'>{unreadCount}</Badge>
+          </div>
+        </div>
+
+        <DropdownMenuSeparator />
+
+        <ScrollArea className='max-h-[360px]'>
+          <div className='p-2'>
+            {recentNotifications.length === 0 ? (
+              <div className='px-4 py-8 text-center'>
+                <Bell className='text-muted-foreground mx-auto h-8 w-8' />
+                <p className='text-foreground mt-3 text-sm font-medium'>No notifications</p>
+                <p className='text-muted-foreground mt-1 text-xs'>You are all caught up.</p>
+              </div>
+            ) : (
+              recentNotifications.map(notification => (
+                <NotificationRow
+                  key={notification.uuid}
+                  notification={notification}
+                  onRead={handleRead}
+                />
+              ))
+            )}
+          </div>
+        </ScrollArea>
+
+        <DropdownMenuSeparator />
+
+        <div className='p-2'>
+          <Button asChild variant='ghost' className='w-full justify-center text-sm'>
+            <Link href={notificationHref}>View all notifications</Link>
+          </Button>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/features/dashboard/components/dashboard-top-bar.tsx
+++ b/src/features/dashboard/components/dashboard-top-bar.tsx
@@ -25,7 +25,6 @@ import {
 import { useUserProfile } from '@/src/features/profile/context/profile-context';
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import {
-  Bell,
   Check,
   ChevronDown,
   Laptop2,
@@ -41,6 +40,7 @@ import { useTheme } from 'next-themes';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { Label } from '../../../../components/ui/label';
+import { DashboardNotifications } from './dashboard-notifications';
 
 const dashboardLabelByDomain = (domain?: string | null) => {
   if (!domain) return 'Dashboard';
@@ -102,8 +102,6 @@ export default function DashboardTopBar() {
 
   const profileName = getProfileName(profile);
   const profileInitials = getInitials(profileName);
-
-  const notificationCount = 0;
 
   const walletOptions = profile?.uuid ? getWalletOptions({ path: { userUuid: profile.uuid } }) : null;
 
@@ -203,22 +201,7 @@ export default function DashboardTopBar() {
               </Button>
             )}
 
-            <Button
-              variant='outline'
-              size='icon'
-              asChild
-              className='border-border/70 bg-card/80 relative hidden h-10 w-10 rounded-md shadow-sm sm:inline-flex'
-            >
-              <Link href={notificationHref} aria-label='Notifications'>
-                <Bell className='h-4 w-4' />
-
-                {notificationCount > 0 && (
-                  <span className='bg-destructive text-destructive-foreground absolute -top-1 -right-1 flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-[10px] font-semibold'>
-                    {notificationCount}
-                  </span>
-                )}
-              </Link>
-            </Button>
+            <DashboardNotifications notificationHref={notificationHref} />
 
             <div className='border-border/70 bg-card/80 hidden h-10 items-center gap-2 rounded-md border px-3 shadow-sm xl:flex'>
               <div className='bg-success/10 text-success flex h-8 w-8 items-center justify-center rounded-full'>


### PR DESCRIPTION
## Summary
Adds the Elimika notification experience to the dashboard UI and introduces React Email source templates for branded transactional email generation.

## Changes
- Added a top-right dashboard notification bell with unread badge, dropdown list, and mark-read support.
- Polls notification counts, recent notifications, and unseen popup notifications every 30 seconds.
- Displays popup notifications as toast banners and marks them popup-seen through the unified action API.
- Replaced the dashboard notifications page sample data with the real notifications API, pagination-aware query hooks, and read/archive actions.
- Added React Email template source and export script for branded Elimika account-created email templates.

## Tests
- pnpm lint
- pnpm build
- git diff --check

## Configuration/Secret Impacts
No new secrets required. Added React Email/tsx development dependencies for template export.