### PR TITLE
fix(notifications): local-time timestamps and per-domain notification views

### DIFF
--- a/app/dashboard/@admin/overview/_components/ActivityFeed.tsx
+++ b/app/dashboard/@admin/overview/_components/ActivityFeed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { formatDistanceToNow } from 'date-fns';
+import { relativeTimeFromNow } from '@/lib/date';
 import Link from 'next/link';
 import {
   AlertCircle,
@@ -116,14 +116,7 @@ const getEventIcon = (event: AdminActivityEvent) => {
 
 const resolveEventTimestamp = (event: AdminActivityEvent): string => {
   const timestamp = event.occurred_at ?? event.created_at ?? event.timestamp;
-  if (!timestamp) return 'a few moments ago';
-
-  const date = new Date(timestamp);
-  if (Number.isNaN(date.getTime())) {
-    return 'a few moments ago';
-  }
-
-  return formatDistanceToNow(date, { addSuffix: true });
+  return relativeTimeFromNow(timestamp, 'a few moments ago');
 };
 
 const resolveEventSummary = (event: AdminActivityEvent): string =>

--- a/app/dashboard/@admin/overview/_components/RecentActivitySummary.tsx
+++ b/app/dashboard/@admin/overview/_components/RecentActivitySummary.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import type { AdminActivityEvent } from '@/services/admin/dashboard';
-import { formatDistanceToNow } from 'date-fns';
+import { relativeTimeFromNow } from '@/lib/date';
 import { Activity, ArrowUpRight } from 'lucide-react';
 
 interface RecentActivitySummaryProps {
@@ -47,7 +47,7 @@ export function RecentActivitySummary({ events, isLoading }: RecentActivitySumma
               event.occurred_at || event.timestamp || event.created_at || event.id || '';
             const relativeTime =
               typeof timestamp === 'string' && timestamp.length
-                ? formatDistanceToNow(new Date(timestamp), { addSuffix: true })
+                ? relativeTimeFromNow(timestamp, 'Just now')
                 : 'Just now';
 
             return (

--- a/app/dashboard/@organization/audit/page.tsx
+++ b/app/dashboard/@organization/audit/page.tsx
@@ -7,7 +7,7 @@ import { useUserProfile } from '@/context/profile-context';
 import { getDashboardStatisticsOptions } from '@/services/client/@tanstack/react-query.gen';
 import { useAdminActivityFeed } from '@/services/admin';
 import { useQuery } from '@tanstack/react-query';
-import { formatDistanceToNow } from 'date-fns';
+import { relativeTimeFromNow } from '@/lib/date';
 import { Activity, BarChart3, ShieldQuestion } from 'lucide-react';
 
 export default function AuditActivityPage() {
@@ -89,9 +89,7 @@ export default function AuditActivityPage() {
               >
                 <p className='font-medium'>{event.title ?? 'Admin event'}</p>
                 <p className='text-muted-foreground text-xs'>
-                  {event.timestamp
-                    ? formatDistanceToNow(new Date(event.timestamp), { addSuffix: true })
-                    : '—'}
+                  {event.timestamp ? relativeTimeFromNow(event.timestamp, '—') : '—'}
                 </p>
                 {event.description ? (
                   <p className='text-muted-foreground text-xs'>{event.description}</p>

--- a/app/dashboard/_components/notifications/AlertsTab.tsx
+++ b/app/dashboard/_components/notifications/AlertsTab.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { Skeleton } from '@/components/ui/skeleton';
 import Spinner from '@/components/ui/spinner';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { absoluteDateTime, relativeTimeFromNow } from '@/lib/date';
 import { cn } from '@/lib/utils';
 import {
   useMarkAllNotificationsRead,
@@ -16,7 +17,6 @@ import {
   type NotificationListParams,
   type UserNotification,
 } from '@/services/notifications';
-import { format, formatDistanceToNow } from 'date-fns';
 import {
   Archive,
   Award,
@@ -89,28 +89,14 @@ function getQueryParams(tab: NotificationTab, page: number): NotificationListPar
   return { page, size: pageSize };
 }
 
-function notificationDate(notification: UserNotification) {
-  const rawDate = notification.occurred_at ?? notification.created_at;
-  if (!rawDate) {
-    return null;
-  }
-
-  const date = new Date(rawDate);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-
-  return date;
-}
-
 function notificationTime(notification: UserNotification) {
-  const date = notificationDate(notification);
-  return date ? formatDistanceToNow(date, { addSuffix: true }) : 'Recently';
+  const rawDate = notification.occurred_at ?? notification.created_at;
+  return relativeTimeFromNow(rawDate, 'Recently');
 }
 
 function notificationExactTime(notification: UserNotification) {
-  const date = notificationDate(notification);
-  return date ? format(date, 'PPp') : 'Recently';
+  const rawDate = notification.occurred_at ?? notification.created_at;
+  return absoluteDateTime(rawDate, 'Recently');
 }
 
 function notificationTypeLabel(value: string) {

--- a/app/dashboard/_components/notifications/AlertsTab.tsx
+++ b/app/dashboard/_components/notifications/AlertsTab.tsx
@@ -9,6 +9,7 @@ import Spinner from '@/components/ui/spinner';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { absoluteDateTime, relativeTimeFromNow } from '@/lib/date';
 import { cn } from '@/lib/utils';
+import type { UserDomain } from '@/lib/types';
 import {
   useMarkAllNotificationsRead,
   useNotificationAction,
@@ -165,18 +166,19 @@ function NotificationLoadingList() {
 
 export function AlertsTab() {
   const [activeTab, setActiveTab] = useState<NotificationTab>('all');
-  const { activeDomain } = useUserDomain()
+  const { activeDomain, setActiveDomain } = useUserDomain()
+  const domain = activeDomain ?? undefined;
   const [page, setPage] = useState(0);
-  const queryParams = getQueryParams(activeTab, page);
+  const queryParams = { ...getQueryParams(activeTab, page), domain };
   const notificationsQuery = useNotifications(queryParams);
-  const countsQuery = useNotificationCounts();
+  const countsQuery = useNotificationCounts(domain);
   const actionMutation = useNotificationAction();
-  const markAllMutation = useMarkAllNotificationsRead();
+  const markAllMutation = useMarkAllNotificationsRead(domain);
 
   const normalizeNotifications = (notifications: UserNotification[], activeDomain: string) => {
     return notifications.map((notification: UserNotification) => ({
       ...notification,
-      urlPath: getNotificationUrlPath(notification, activeDomain),
+      urlPath: getNotificationUrlPath(notification, notification.recipient_domain ?? activeDomain),
     }));
   };
 
@@ -204,6 +206,14 @@ export function AlertsTab() {
         onError: () => toast.error('Could not mark notification as read'),
       }
     );
+  };
+
+  const handleOpen = (notification: UserNotification) => {
+    const target = notification.recipient_domain;
+    if (target && target !== activeDomain) {
+      setActiveDomain(target as UserDomain);
+    }
+    handleMarkAsRead(notification);
   };
 
   const handleArchive = (notification: UserNotification) => {
@@ -431,7 +441,7 @@ export function AlertsTab() {
                                 <Button
                                   asChild
                                   size='sm'
-                                  onClick={() => handleMarkAsRead(notification)}
+                                  onClick={() => handleOpen(notification)}
                                 >
                                   <Link href={notification.urlPath}>
                                     <ExternalLink className='h-4 w-4' />

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -2,10 +2,12 @@ import dayjs from 'dayjs';
 import advancedFormat from 'dayjs/plugin/advancedFormat';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import utc from 'dayjs/plugin/utc';
 
 dayjs.extend(advancedFormat);
 dayjs.extend(localizedFormat);
 dayjs.extend(relativeTime);
+dayjs.extend(utc);
 
 export { dayjs };
 
@@ -17,4 +19,65 @@ export { dayjs };
  */
 export function localDate(value: Date | string): Date {
   return dayjs(value).format('YYYY-MM-DD') as unknown as Date;
+}
+
+type ApiDateInput = string | number | Date | null | undefined;
+
+// Matches an explicit UTC ("Z") or numeric offset ("+03:00", "-0500") suffix.
+const HAS_TIMEZONE = /(?:Z|[+-]\d{2}:?\d{2})$/i;
+
+/**
+ * Parse a timestamp returned by the API into a `dayjs` instant.
+ *
+ * The backend serializes Java `LocalDateTime` values, which are UTC instants
+ * emitted WITHOUT a timezone designator (e.g. `2026-07-09T09:00:00`). A plain
+ * `new Date(...)`/`dayjs(...)` reads those as browser-local time and is wrong
+ * by the viewer's UTC offset, so zone-less strings are interpreted as UTC.
+ * Strings that already carry a `Z` or numeric offset are parsed as-is.
+ *
+ * Returns `null` for empty or unparseable input so callers can fall back.
+ */
+export function parseApiDate(value: ApiDateInput) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const parsed =
+    typeof value === 'string' && !HAS_TIMEZONE.test(value.trim())
+      ? dayjs.utc(value)
+      : dayjs(value);
+
+  return parsed.isValid() ? parsed : null;
+}
+
+/**
+ * Human-friendly "time ago" label that stays correct across time zones and is
+ * granular down to seconds for very recent instants (e.g. "just now",
+ * "12 seconds ago") instead of the coarse "less than a minute ago".
+ */
+export function relativeTimeFromNow(value: ApiDateInput, fallback = ''): string {
+  const date = parseApiDate(value);
+  if (!date) {
+    return fallback;
+  }
+
+  const diffSeconds = dayjs().diff(date, 'second');
+
+  if (diffSeconds >= 0 && diffSeconds < 60) {
+    if (diffSeconds < 5) {
+      return 'just now';
+    }
+    return `${diffSeconds} seconds ago`;
+  }
+
+  return date.fromNow();
+}
+
+/**
+ * Absolute timestamp rendered in the viewer's local time zone, with the UTC
+ * offset appended so the zone is unambiguous. Suited for tooltips/hover titles.
+ */
+export function absoluteDateTime(value: ApiDateInput, fallback = ''): string {
+  const date = parseApiDate(value);
+  return date ? date.local().format('MMM D, YYYY h:mm A [GMT]Z') : fallback;
 }

--- a/services/notifications.ts
+++ b/services/notifications.ts
@@ -18,6 +18,7 @@ const notificationMetadataSchema = z.object({
 const notificationSchema = z.object({
   uuid: z.string().uuid(),
   notification_id: z.string().uuid().nullable().optional(),
+  recipient_domain: z.string().nullable().optional(),
   type: z.string(),
   category: z.string().nullable().optional(),
   priority: z.string().default('NORMAL'),
@@ -78,6 +79,7 @@ export type UserNotification = z.infer<typeof notificationSchema>;
 export interface NotificationListParams {
   page?: number;
   size?: number;
+  domain?: string;
   status?: 'UNREAD' | 'READ' | 'ARCHIVED';
   presentation?: 'POPUP' | 'INBOX';
   type?: string;
@@ -107,7 +109,8 @@ const defaultListParams = {
 export const notificationListQueryKey = (params: NotificationListParams = {}) =>
   ['notifications', 'list', normalizeListParams(params)] as const;
 
-export const notificationCountsQueryKey = ['notifications', 'counts'] as const;
+export const notificationCountsQueryKey = (domain?: string) =>
+  ['notifications', 'counts', domain ?? null] as const;
 
 function normalizeListParams(params: NotificationListParams = {}): NotificationListParams {
   return {
@@ -127,6 +130,7 @@ export async function fetchNotifications(
         page: normalizedParams.page,
         size: normalizedParams.size,
         sort: 'createdDate,desc',
+        domain: normalizedParams.domain,
         status: normalizedParams.status,
         presentation: normalizedParams.presentation,
         type: normalizedParams.type,
@@ -166,8 +170,10 @@ export async function fetchNotifications(
   };
 }
 
-export async function fetchNotificationCounts(): Promise<NotificationCounts> {
-  const response = await fetchClient.GET('/api/v1/notifications/counts' as never);
+export async function fetchNotificationCounts(domain?: string): Promise<NotificationCounts> {
+  const response = await fetchClient.GET('/api/v1/notifications/counts' as never, {
+    params: { query: { domain } },
+  } as never);
 
   if (response.error) {
     throw new Error(
@@ -200,10 +206,10 @@ async function applyNotificationAction(uuid: string, action: 'read' | 'archive' 
   return notificationActionResponseSchema.parse(response.data ?? {});
 }
 
-async function markAllNotificationsRead() {
+async function markAllNotificationsRead(domain?: string) {
   const response = await fetchClient.POST('/api/v1/notifications' as never, {
     params: {
-      query: { action: 'read_all' },
+      query: { action: 'read_all', domain },
     },
   } as never);
 
@@ -231,11 +237,12 @@ export function useNotifications(
 }
 
 export function useNotificationCounts(
+  domain?: string,
   options?: Partial<UseQueryOptions<NotificationCounts, Error>>
 ) {
   return useQuery({
-    queryKey: notificationCountsQueryKey,
-    queryFn: fetchNotificationCounts,
+    queryKey: notificationCountsQueryKey(domain),
+    queryFn: () => fetchNotificationCounts(domain),
     refetchInterval: 30_000,
     ...options,
   });
@@ -253,11 +260,11 @@ export function useNotificationAction() {
   });
 }
 
-export function useMarkAllNotificationsRead() {
+export function useMarkAllNotificationsRead(domain?: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: markAllNotificationsRead,
+    mutationFn: () => markAllNotificationsRead(domain),
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['notifications'] });
     },

--- a/src/features/dashboard/components/dashboard-notifications.tsx
+++ b/src/features/dashboard/components/dashboard-notifications.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { absoluteDateTime, relativeTimeFromNow } from '@/lib/date';
 import { cn } from '@/lib/utils';
 import {
   useMarkAllNotificationsRead,
@@ -18,7 +19,6 @@ import {
   useNotifications,
   type UserNotification,
 } from '@/services/notifications';
-import { formatDistanceToNow } from 'date-fns';
 import {
   Award,
   Bell,
@@ -56,16 +56,7 @@ function notificationIcon(type: string) {
 
 function notificationTime(notification: UserNotification) {
   const rawDate = notification.occurred_at ?? notification.created_at;
-  if (!rawDate) {
-    return '';
-  }
-
-  const date = new Date(rawDate);
-  if (Number.isNaN(date.getTime())) {
-    return '';
-  }
-
-  return formatDistanceToNow(date, { addSuffix: true });
+  return relativeTimeFromNow(rawDate);
 }
 
 function NotificationRow({
@@ -105,7 +96,12 @@ function NotificationRow({
           <p className='text-muted-foreground mt-1 line-clamp-2 text-xs leading-5'>
             {notification.body}
           </p>
-          <p className='text-muted-foreground mt-2 text-[11px]'>{notificationTime(notification)}</p>
+          <p
+            className='text-muted-foreground mt-2 text-[11px]'
+            title={absoluteDateTime(notification.occurred_at ?? notification.created_at)}
+          >
+            {notificationTime(notification)}
+          </p>
         </div>
       </div>
     </Link>

--- a/src/features/dashboard/components/dashboard-notifications.tsx
+++ b/src/features/dashboard/components/dashboard-notifications.tsx
@@ -212,28 +212,31 @@ export const getNotificationUrlPath = (
 export function DashboardNotifications({ notificationHref, activeDomain }: DashboardNotificationsProps) {
   const [open, setOpen] = useState(false);
   const shownPopupIds = useRef<Set<string>>(new Set());
+  const domain = activeDomain ?? undefined;
   const actionMutation = useNotificationAction();
-  const markAllMutation = useMarkAllNotificationsRead();
+  const markAllMutation = useMarkAllNotificationsRead(domain);
 
   const normalizeNotifications = (notifications: UserNotification[], activeDomain: string) => {
     return notifications.map((notification: UserNotification) => ({
       ...notification,
-      urlPath: getNotificationUrlPath(notification, activeDomain),
+      urlPath: getNotificationUrlPath(notification, notification.recipient_domain ?? activeDomain),
     }));
   };
 
   // The badge needs counts and toasts need the popup feed, but the recent
   // list is only visible inside the dropdown — fetch it when opened instead
-  // of on every page load.
-  const countsQuery = useNotificationCounts({ refetchInterval: 60_000 });
+  // of on every page load. Every query is scoped to the active dashboard
+  // domain so a multi-domain user only sees the relevant notifications here.
+  const countsQuery = useNotificationCounts(domain, { refetchInterval: 60_000 });
   const recentQuery = useNotifications(
-    { page: 0, size: 6 },
+    { page: 0, size: 6, domain },
     { enabled: open, refetchInterval: open ? 30_000 : false }
   );
   const popupQuery = useNotifications(
     {
       page: 0,
       size: 5,
+      domain,
       presentation: 'POPUP',
       popupSeen: false,
     },


### PR DESCRIPTION
## Summary
Two related fixes to how notifications are displayed.

### 1. Timezone-correct, second-granular timestamps
The API serializes UTC instants; `new Date(...)` read them as browser-local time, shifting every notification by the viewer's offset (e.g. 3h in Nairobi), and relative labels were coarse ("less than a minute ago").

- `lib/date.ts` gains `parseApiDate` (zone-less strings → UTC), `relativeTimeFromNow` (`just now` <5s, `N seconds ago` <60s, else `fromNow`), and `absoluteDateTime` (local time + `GMT±hh:mm` tooltip).
- Wired into the notifications page, the bell dropdown, the org audit page, and both admin activity feeds (same latent bug).

### 2. Per-domain notification views
A multi-domain user (e.g. student + instructor) saw one merged inbox in every dashboard, and "Open" links were built from the active domain, misrouting notifications that belonged to another domain.

- `domain` threaded through the list, counts, popup, and mark-all queries so each dashboard shows and counts only its own notifications (plus account-level ones).
- Deep-links now build from each notification's own `recipient_domain`, falling back to the active domain for account-level items.
- Opening a cross-domain notification switches the active domain first, so navigation lands in the correct dashboard.

Depends on the matching backend PR (adds `recipient_domain` and the `domain` query param).

## Verification
- `tsc` — no new type errors in the touched files (the pre-existing `as never` baseline is unchanged).
- Relative-time logic runtime-verified in `Africa/Nairobi` (UTC+3).
