### PR TITLE
feat(courses): surface the draft-over-live edit review workflow

### DIFF
--- a/app/dashboard/@admin/manage-courses/[uuid]/_components/CourseReviewPage.tsx
+++ b/app/dashboard/@admin/manage-courses/[uuid]/_components/CourseReviewPage.tsx
@@ -8,10 +8,11 @@ import { toast } from 'sonner';
 import HTMLTextPreview from '@/components/editors/html-text-preview';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import type { Course } from '@/services/client';
+import type { Course, CoursePendingEdit } from '@/services/client';
 import {
   getCourseByUuidOptions,
   getCourseCreatorByUuidOptions,
+  getPendingEditOptions,
   moderateCourseMutation,
 } from '@/services/client/@tanstack/react-query.gen';
 import { adminTheme } from '../../../_components/ui/admin-theme';
@@ -20,6 +21,7 @@ import { AssessmentsSection } from './AssessmentsSection';
 import { CurriculumSection } from './CurriculumSection';
 import { ModerationHistorySection } from './ModerationHistorySection';
 import { ModerationSheet, type ModerationSheetAction } from './ModerationSheet';
+import { PendingEditSection } from './PendingEditSection';
 import { RequirementsSection } from './RequirementsSection';
 import { ReviewHero } from './ReviewHero';
 import { ReviewSidebar } from './ReviewSidebar';
@@ -30,10 +32,19 @@ const MODERATION_QUERY_IDS = new Set([
   'getCourseByUuid',
   'getAllCourses',
   'listPendingCourses',
+  'listPendingCourseEdits',
+  'getCourseEditDiff',
   'getCourseModerationHistory',
   'getCourseApprovalStatus',
   'searchCourses',
 ]);
+
+/** The API takes `approved` / `rejected` / `revoked`; the UI speaks in verbs. */
+const MODERATION_ACTIONS = {
+  approve: 'approved',
+  reject: 'rejected',
+  revoke: 'revoked',
+} as const;
 
 export function CourseReviewPage({ uuid }: { uuid: string }) {
   const queryClient = useQueryClient();
@@ -46,18 +57,34 @@ export function CourseReviewPage({ uuid }: { uuid: string }) {
   });
   const creatorName = creatorData?.full_name;
 
+  // A published course can have an edit awaiting review. When it does, a decision applies to
+  // that edit rather than to the course's own approval, so the wording has to change with it.
+  const { data: pendingEditData } = useQuery({
+    ...getPendingEditOptions({ path: { uuid } }),
+    enabled: !!course,
+  });
+  const pendingEdit = pendingEditData?.data as CoursePendingEdit | undefined;
+  const hasPendingEdit = !!pendingEdit;
+
   const moderate = useMutation(moderateCourseMutation());
   const [sheetAction, setSheetAction] = useState<ModerationSheetAction>('reject');
   const [sheetOpen, setSheetOpen] = useState(false);
 
   const runModerate = async (action: 'approve' | 'reject' | 'revoke', reason?: string) => {
     try {
-      await moderate.mutateAsync({ path: { uuid }, query: { action, reason } });
+      await moderate.mutateAsync({
+        path: { uuid },
+        body: { action: MODERATION_ACTIONS[action], reason },
+      });
       toast.success(
         action === 'approve'
-          ? 'Course approved'
+          ? hasPendingEdit
+            ? 'Edit approved and published'
+            : 'Course approved'
           : action === 'reject'
-            ? 'Course rejected'
+            ? hasPendingEdit
+              ? 'Edit rejected. The live course is unchanged.'
+              : 'Course rejected'
             : 'Approval revoked'
       );
       setSheetOpen(false);
@@ -123,6 +150,8 @@ export function CourseReviewPage({ uuid }: { uuid: string }) {
         <div className='grid items-start gap-4 lg:grid-cols-[minmax(0,1fr)_340px]'>
           {/* Main review column */}
           <div className='min-w-0 space-y-4'>
+            {pendingEdit && <PendingEditSection courseUuid={uuid} pendingEdit={pendingEdit} />}
+
             <SectionCard title='About this course' description='What the course promises learners.'>
               <div className='space-y-5'>
                 <div>
@@ -158,6 +187,7 @@ export function CourseReviewPage({ uuid }: { uuid: string }) {
             <ReviewSidebar
               course={course}
               isPending={moderate.isPending}
+              hasPendingEdit={hasPendingEdit}
               onApprove={() => runModerate('approve')}
               onReject={() => openSheet('reject')}
               onRevoke={() => openSheet('revoke')}
@@ -172,6 +202,7 @@ export function CourseReviewPage({ uuid }: { uuid: string }) {
         onOpenChange={setSheetOpen}
         onConfirm={reason => runModerate(sheetAction, reason)}
         isPending={moderate.isPending}
+        isEditReview={hasPendingEdit}
       />
     </main>
   );

--- a/app/dashboard/@admin/manage-courses/[uuid]/_components/ModerationSheet.tsx
+++ b/app/dashboard/@admin/manage-courses/[uuid]/_components/ModerationSheet.tsx
@@ -14,10 +14,9 @@ import { Textarea } from '@/components/ui/textarea';
 
 export type ModerationSheetAction = 'reject' | 'revoke';
 
-const COPY: Record<
-  ModerationSheetAction,
-  { title: string; description: string; confirm: string; placeholder: string }
-> = {
+type Copy = { title: string; description: string; confirm: string; placeholder: string };
+
+const COPY: Record<ModerationSheetAction, Copy> = {
   reject: {
     title: 'Reject course',
     description:
@@ -34,21 +33,33 @@ const COPY: Record<
   },
 };
 
+/** Rejecting a proposed edit is not rejecting the course: the published course survives it. */
+const REJECT_EDIT_COPY: Copy = {
+  title: 'Reject proposed changes',
+  description:
+    'The changes are discarded and the published course carries on unchanged, still approved and still accepting enrollments. The creator is notified with your reason.',
+  confirm: 'Reject changes',
+  placeholder: 'Explain what needs to change before these edits can go live…',
+};
+
 export function ModerationSheet({
   action,
   open,
   onOpenChange,
   onConfirm,
   isPending,
+  isEditReview = false,
 }: {
   action: ModerationSheetAction;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onConfirm: (reason?: string) => void;
   isPending: boolean;
+  /** The decision applies to a pending edit rather than to the course itself. */
+  isEditReview?: boolean;
 }) {
   const [reason, setReason] = useState('');
-  const copy = COPY[action];
+  const copy = isEditReview && action === 'reject' ? REJECT_EDIT_COPY : COPY[action];
 
   return (
     <Sheet

--- a/app/dashboard/@admin/manage-courses/[uuid]/_components/PendingEditSection.tsx
+++ b/app/dashboard/@admin/manage-courses/[uuid]/_components/PendingEditSection.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { FilePenLine } from 'lucide-react';
+import type { CourseEditDiff, CoursePendingEdit } from '@/services/client';
+import { getCourseEditDiffOptions } from '@/services/client/@tanstack/react-query.gen';
+import { adminTheme } from '../../../_components/ui/admin-theme';
+import { SectionCard, SectionCardSkeleton } from '../../../_components/ui/SectionCard';
+
+/** Renders "—" for an absent value so an added or cleared field is still legible. */
+function Value({ children }: { children?: string | null }) {
+  if (!children) {
+    return <span className='text-muted-foreground'>—</span>;
+  }
+  return <span>{children}</span>;
+}
+
+function CountPill({ label, count }: { label: string; count: number }) {
+  return (
+    <div className='rounded-md border border-border bg-card px-3 py-2'>
+      <p className='text-lg font-semibold tabular-nums'>{count}</p>
+      <p className='text-xs text-muted-foreground'>{label}</p>
+    </div>
+  );
+}
+
+/**
+ * What a creator's pending edit would change if approved.
+ *
+ * Only shown while an edit is awaiting review. The live course keeps serving its approved
+ * content throughout, so this is a preview of a proposal, not of anything learners can see.
+ */
+export function PendingEditSection({
+  courseUuid,
+  pendingEdit,
+}: {
+  courseUuid: string;
+  pendingEdit: CoursePendingEdit;
+}) {
+  const { data, isLoading } = useQuery(getCourseEditDiffOptions({ path: { uuid: courseUuid } }));
+  const diff = data?.data as CourseEditDiff | undefined;
+
+  if (isLoading) {
+    return <SectionCardSkeleton rows={4} />;
+  }
+
+  const fieldChanges = diff?.field_changes ?? [];
+  const submittedAt = pendingEdit.submitted_at
+    ? new Date(pendingEdit.submitted_at).toLocaleString()
+    : undefined;
+
+  return (
+    <SectionCard
+      title='Proposed changes'
+      description={
+        submittedAt
+          ? `Submitted ${submittedAt}. Learners still see the approved version.`
+          : 'Learners still see the approved version.'
+      }
+    >
+      <div className='space-y-5'>
+        <div className='grid grid-cols-3 gap-2'>
+          <CountPill label='Lessons added' count={diff?.lessons_added ?? 0} />
+          <CountPill label='Lessons removed' count={diff?.lessons_removed ?? 0} />
+          <CountPill label='Lessons changed' count={diff?.lessons_modified ?? 0} />
+        </div>
+
+        {fieldChanges.length === 0 ? (
+          <p className='text-sm text-muted-foreground'>
+            No course fields changed. The edit only affects the curriculum.
+          </p>
+        ) : (
+          <div>
+            <p className={adminTheme.sectionLabel}>Field changes</p>
+            <div className='mt-2 overflow-x-auto'>
+              <table className='w-full min-w-[32rem] border-collapse text-sm'>
+                <thead>
+                  <tr className='border-b border-border text-left text-xs text-muted-foreground'>
+                    <th className='py-2 pr-4 font-medium'>Field</th>
+                    <th className='py-2 pr-4 font-medium'>Live now</th>
+                    <th className='py-2 font-medium'>Proposed</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {fieldChanges.map(change => (
+                    <tr key={change.field} className='border-b border-border/60 align-top'>
+                      <td className='py-2 pr-4 font-medium'>{change.field}</td>
+                      <td className='py-2 pr-4 text-muted-foreground'>
+                        <Value>{change.live_value}</Value>
+                      </td>
+                      <td className='py-2'>
+                        <Value>{change.draft_value}</Value>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        <p className='flex items-start gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground'>
+          <FilePenLine className='mt-0.5 size-3.5 shrink-0' />
+          <span>
+            Approving replaces the live content with these changes. Rejecting discards them and
+            leaves the published course exactly as it is.
+          </span>
+        </p>
+      </div>
+    </SectionCard>
+  );
+}

--- a/app/dashboard/@admin/manage-courses/[uuid]/_components/ReviewSidebar.tsx
+++ b/app/dashboard/@admin/manage-courses/[uuid]/_components/ReviewSidebar.tsx
@@ -25,12 +25,15 @@ function Row({ label, value }: { label: string; value: React.ReactNode }) {
 export function ReviewSidebar({
   course,
   isPending,
+  hasPendingEdit = false,
   onApprove,
   onReject,
   onRevoke,
 }: {
   course: Course;
   isPending: boolean;
+  /** The course is live and approved, but its creator has an edit awaiting a decision. */
+  hasPendingEdit?: boolean;
   onApprove: () => void;
   onReject: () => void;
   onRevoke: () => void;
@@ -44,9 +47,28 @@ export function ReviewSidebar({
     <aside className='space-y-4'>
       {/* Decision panel */}
       <div className={adminTheme.cardPadded}>
-        <p className={adminTheme.sectionLabel}>Moderation decision</p>
+        <p className={adminTheme.sectionLabel}>
+          {hasPendingEdit ? 'Review proposed changes' : 'Moderation decision'}
+        </p>
         <div className='mt-3 flex flex-col gap-2'>
-          {approved ? (
+          {hasPendingEdit ? (
+            // The course is approved and live, but the decision here is about the creator's
+            // proposed edit, not about the published course.
+            <>
+              <p className='text-sm text-muted-foreground'>
+                This course stays published either way. Approving replaces the live content;
+                rejecting discards the changes.
+              </p>
+              <Button onClick={onApprove} disabled={isPending}>
+                <CheckCircle2 className='size-4' />
+                Approve changes
+              </Button>
+              <Button variant='outline' onClick={onReject} disabled={isPending}>
+                <XCircle className='size-4' />
+                Reject with feedback
+              </Button>
+            </>
+          ) : approved ? (
             <>
               <p className='text-sm text-muted-foreground'>
                 This course is approved and can accept enrollments.

--- a/app/dashboard/@admin/manage-courses/_components/CoursesTable.tsx
+++ b/app/dashboard/@admin/manage-courses/_components/CoursesTable.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import type { Course } from '@/services/client';
+import type { Course, CoursePendingEdit } from '@/services/client';
 import {
   getAllCoursesOptions,
+  getCourseByUuidOptions,
+  listPendingCourseEditsOptions,
   listPendingCoursesOptions,
 } from '@/services/client/@tanstack/react-query.gen';
 import { toAuthenticatedMediaUrl } from '@/src/lib/media-url';
@@ -144,26 +146,130 @@ function CoursesTableView({ courses, isLoading }: { courses: Course[]; isLoading
   );
 }
 
+/**
+ * Edits awaiting review on courses that are already live.
+ *
+ * Deliberately a separate view from the course queues: the course itself is fine and
+ * published, and only the proposed change needs a decision.
+ */
+function PendingEditsTableView({
+  edits,
+  isLoading,
+}: {
+  edits: CoursePendingEdit[];
+  isLoading: boolean;
+}) {
+  const router = useRouter();
+
+  const columns = useMemo<ColumnDef<CoursePendingEdit>[]>(
+    () => [
+      {
+        id: 'course',
+        header: 'Course',
+        accessorFn: row => row.course_uuid ?? '',
+        cell: ({ row }) => <PendingEditCourseCell courseUuid={row.original.course_uuid} />,
+      },
+      {
+        id: 'submitted',
+        header: 'Submitted',
+        accessorFn: row => row.submitted_at ?? '',
+        cell: ({ row }) => (
+          <span className='text-sm text-muted-foreground'>
+            {row.original.submitted_at
+              ? new Date(row.original.submitted_at).toLocaleString()
+              : '—'}
+          </span>
+        ),
+      },
+      {
+        id: 'actions',
+        header: '',
+        enableSorting: false,
+        cell: ({ row }) => (
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={e => {
+              e.stopPropagation();
+              if (row.original.course_uuid) {
+                router.push(`/dashboard/manage-courses/${row.original.course_uuid}`);
+              }
+            }}
+          >
+            Review
+          </Button>
+        ),
+      },
+    ],
+    [router]
+  );
+
+  return (
+    <AdminTable
+      columns={columns}
+      data={edits}
+      isLoading={isLoading}
+      searchPlaceholder='Search pending edits…'
+      getRowId={(edit, index) => edit.uuid ?? String(index)}
+      onRowClick={edit => {
+        if (edit.course_uuid) router.push(`/dashboard/manage-courses/${edit.course_uuid}`);
+      }}
+      pageSize={12}
+      emptyTitle='No edits awaiting review'
+      emptyDescription='Published courses with proposed changes will appear here.'
+    />
+  );
+}
+
+/** Resolves the course name for a pending edit row, which only carries uuids. */
+function PendingEditCourseCell({ courseUuid }: { courseUuid?: string }) {
+  const { data } = useQuery({
+    ...getCourseByUuidOptions({ path: { uuid: courseUuid as string } }),
+    enabled: !!courseUuid,
+  });
+  const course = data?.data as Course | undefined;
+
+  return (
+    <div className='flex items-center gap-3'>
+      <Thumb url={course?.thumbnail_url} alt={course?.name ?? 'Course'} />
+      <div className='min-w-0'>
+        <p className='truncate text-sm font-medium'>{course?.name ?? 'Loading…'}</p>
+        <p className='truncate text-xs text-muted-foreground'>Still live · showing approved version</p>
+      </div>
+    </div>
+  );
+}
+
 export function CoursesTable() {
   const allQuery = useQuery(getAllCoursesOptions({ query: { pageable: { page: 0, size: 100 } } }));
   const pendingQuery = useQuery(
     listPendingCoursesOptions({ query: { pageable: { page: 0, size: 100 } } })
   );
+  // Edits to already-published courses. These never appear in the queue above: the live
+  // course keeps admin_approved = true while its edit is reviewed.
+  const pendingEditsQuery = useQuery(
+    listPendingCourseEditsOptions({ query: { pageable: { page: 0, size: 100 } } })
+  );
 
   const allCourses = (allQuery.data?.data?.content ?? []) as Course[];
   const pendingCourses = (pendingQuery.data?.data?.content ?? []) as Course[];
+  const pendingEdits = (pendingEditsQuery.data?.data?.content ?? []) as CoursePendingEdit[];
 
   return (
     <Tabs defaultValue='all' className='space-y-3'>
       <TabsList>
         <TabsTrigger value='all'>All courses · {allCourses.length}</TabsTrigger>
         <TabsTrigger value='pending'>Pending review · {pendingCourses.length}</TabsTrigger>
+        <TabsTrigger value='pending-edits'>Pending edits · {pendingEdits.length}</TabsTrigger>
       </TabsList>
       <TabsContent value='all' className='mt-0'>
         <CoursesTableView courses={allCourses} isLoading={allQuery.isLoading} />
       </TabsContent>
       <TabsContent value='pending' className='mt-0'>
         <CoursesTableView courses={pendingCourses} isLoading={pendingQuery.isLoading} />
+      </TabsContent>
+      <TabsContent value='pending-edits' className='mt-0'>
+        <PendingEditsTableView edits={pendingEdits} isLoading={pendingEditsQuery.isLoading} />
       </TabsContent>
     </Tabs>
   );

--- a/app/dashboard/@admin/users/_components/ContentApprovalsTab.tsx
+++ b/app/dashboard/@admin/users/_components/ContentApprovalsTab.tsx
@@ -39,9 +39,15 @@ function ContentRow({
 
   const run = async (action: 'approve' | 'reject', actionReason?: string) => {
     if (!item.uuid) return;
-    const mutation = item.type === 'course' ? moderateCourse : moderateProgram;
+    // The API takes the decision in the body as `approved` / `rejected` / `revoked`.
+    const body = {
+      action: action === 'approve' ? ('approved' as const) : ('rejected' as const),
+      reason: actionReason,
+    };
     try {
-      await mutation.mutateAsync({ path: { uuid: item.uuid }, query: { action, reason: actionReason } });
+      await (item.type === 'course'
+        ? moderateCourse.mutateAsync({ path: { uuid: item.uuid }, body })
+        : moderateProgram.mutateAsync({ path: { uuid: item.uuid }, body }));
       toast.success(action === 'approve' ? `${item.title} approved` : `${item.title} rejected`);
       setRejecting(false);
       setReason('');

--- a/app/dashboard/@course_creator/_components/course-branding-form.tsx
+++ b/app/dashboard/@course_creator/_components/course-branding-form.tsx
@@ -44,9 +44,10 @@ type UploadResponse = unknown;
 type UploadError = unknown;
 type UpdateCourseVariables = MutationVariables<ReturnType<typeof updateCourseMutation>>;
 type UpdateCourseResponse = MutationResponse<ReturnType<typeof updateCourseMutation>>;
+// No `status` here on purpose: an update never sets lifecycle. Requiring it was what made
+// every branding save demote a published course to draft.
 type CourseUpdatePayload = Partial<CourseCreationFormValues> & {
   course_creator_uuid: string;
-  status: string;
 };
 
 const isString = (value: unknown): value is string => typeof value === 'string';
@@ -191,7 +192,9 @@ export const CourseBrandingForm = forwardRef<CourseFormRef, CourseFormProps>(
       if (editingCourseId) {
         const editBody: CourseUpdatePayload = {
           course_creator_uuid: authorUuid,
-          status: 'draft',
+          // No status here: branding is cosmetic and must never change whether the course
+          // is published. This previously demoted a live course to draft just for a theme
+          // colour change.
           ...initialValues,
           welcome_message: data?.welcome_message,
           theme_color: data?.theme_color,

--- a/app/dashboard/@course_creator/_components/course-creation-form.tsx
+++ b/app/dashboard/@course_creator/_components/course-creation-form.tsx
@@ -408,11 +408,11 @@ export const CourseCreationForm = forwardRef<CourseFormRef, CourseFormProps>(
           creator_share_percentage: data?.creator_share_percentage,
           instructor_share_percentage: data?.instructor_share_percentage,
           revenue_share_notes: data?.revenue_share_notes,
-          status: 'draft',
-          active: false,
+          // Lifecycle is never set from an edit. Sending status/active here demoted a
+          // published course to draft on every save, which is what took live courses off
+          // the catalogue when their creator edited them. Publishing and unpublishing go
+          // through their own endpoints; the API now ignores these fields on update.
           is_free: data?.is_free,
-          is_published: false,
-          is_draft: true,
           age_lower_limit: data?.age_lower_limit,
           age_upper_limit: data?.age_upper_limit,
         };

--- a/app/dashboard/@course_creator/_components/pending-edit-banner.tsx
+++ b/app/dashboard/@course_creator/_components/pending-edit-banner.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Clock, Undo2 } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+  getPendingEditOptions,
+  getPendingEditQueryKey,
+  withdrawPendingEditMutation,
+} from '@/services/client/@tanstack/react-query.gen';
+
+/**
+ * Tells a creator that their edit is waiting on an admin, and that learners are still being
+ * served the previously approved version in the meantime.
+ *
+ * Without this, saving an edit to a published course looks like nothing happened: the form
+ * reloads the live course, which deliberately still shows the old content.
+ */
+export function PendingEditBanner({ courseUuid }: { courseUuid: string }) {
+  const queryClient = useQueryClient();
+  const [confirming, setConfirming] = useState(false);
+
+  const { data } = useQuery({
+    ...getPendingEditOptions({ path: { uuid: courseUuid } }),
+    enabled: !!courseUuid,
+  });
+  const pendingEdit = data?.data;
+
+  const withdraw = useMutation(withdrawPendingEditMutation());
+
+  if (!pendingEdit) return null;
+
+  const submittedAt = pendingEdit.submitted_at
+    ? new Date(pendingEdit.submitted_at).toLocaleString()
+    : undefined;
+
+  const onWithdraw = async () => {
+    try {
+      await withdraw.mutateAsync({ path: { uuid: courseUuid } });
+      toast.success('Changes withdrawn. Your course is unchanged.');
+      setConfirming(false);
+      queryClient.invalidateQueries({
+        queryKey: getPendingEditQueryKey({ path: { uuid: courseUuid } }),
+      });
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Could not withdraw the changes');
+    }
+  };
+
+  return (
+    <div className='flex flex-col gap-3 rounded-md border border-warning/40 bg-warning/10 p-4 sm:flex-row sm:items-center sm:justify-between'>
+      <div className='flex min-w-0 items-start gap-3'>
+        <Clock className='mt-0.5 size-4 shrink-0 text-warning' />
+        <div className='min-w-0'>
+          <p className='text-sm font-medium'>Your changes are waiting for review</p>
+          <p className='mt-0.5 text-sm text-muted-foreground'>
+            Your course stays published and learners keep seeing the approved version until an
+            admin reviews these changes.
+            {submittedAt ? ` Submitted ${submittedAt}.` : ''}
+          </p>
+        </div>
+      </div>
+
+      {confirming ? (
+        <div className='flex shrink-0 gap-2'>
+          <Button
+            variant='destructive'
+            size='sm'
+            onClick={onWithdraw}
+            disabled={withdraw.isPending}
+          >
+            Discard changes
+          </Button>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={() => setConfirming(false)}
+            disabled={withdraw.isPending}
+          >
+            Keep them
+          </Button>
+        </div>
+      ) : (
+        <Button
+          variant='outline'
+          size='sm'
+          className='shrink-0'
+          onClick={() => setConfirming(true)}
+        >
+          <Undo2 className='size-4' />
+          Withdraw changes
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/app/dashboard/@course_creator/course-management/create-new-course/_component/CourseCreationPage.tsx
+++ b/app/dashboard/@course_creator/course-management/create-new-course/_component/CourseCreationPage.tsx
@@ -17,6 +17,7 @@ import {
   unpublishCourseMutation,
   unpublishCourseQueryKey,
 } from '../../../../../../services/client/@tanstack/react-query.gen';
+import { PendingEditBanner } from '../../../_components/pending-edit-banner';
 import CourseBuilderPage from './CourseBuilderPage';
 import CoursePreviewPage from './CoursePreviewPage';
 
@@ -164,6 +165,8 @@ const CourseCreationPage = () => {
           )}
         </div>
       </div>
+
+      {courseId && <PendingEditBanner courseUuid={courseId} />}
 
       <div className=''>
         {activeTab === 'builder' && <CourseBuilderPage />}

--- a/app/dashboard/@instructor/assignment/_components/AssignmentSubmissionOverlay.tsx
+++ b/app/dashboard/@instructor/assignment/_components/AssignmentSubmissionOverlay.tsx
@@ -106,6 +106,9 @@ export function AssignmentSubmissionOverlay({ taskId }: AssignmentSubmissionOver
   });
 
   const task = assignmentQuery.data?.data ?? quizQuery.data?.data ?? null;
+  // Narrowed view: assignment-only fields (due_date, max_points) live on the assignment
+  // query's payload, which is only populated for assignment tasks.
+  const assignmentTask = assignmentQuery.data?.data ?? null;
 
   const course = classDetails.course;
   const lessonTitle =
@@ -256,7 +259,9 @@ export function AssignmentSubmissionOverlay({ taskId }: AssignmentSubmissionOver
     return {
       ctaLabel: parsedTask.taskType === 'assignment' ? 'Grade Submission' : 'View Attempt',
       dueLabel: formatDateLabel(
-        parsedTask.taskType === 'assignment' ? task.due_date : selectedAttempt?.submitted_at
+        (parsedTask.taskType === 'assignment'
+          ? assignmentTask?.due_date
+          : selectedAttempt?.submitted_at) ?? undefined
       ),
       iconTone: 'blue',
       id: taskId,
@@ -270,7 +275,7 @@ export function AssignmentSubmissionOverlay({ taskId }: AssignmentSubmissionOver
       studentSummary: course?.name,
       subtitle: task.title,
       taskType: parsedTask.taskType,
-      max_point: task?.max_points
+      max_point: assignmentTask?.max_points
     };
   }, [classDetails.class?.title, course?.name, lessonTitle, parsedTask, rubricUuid, selectedAttempt?.submitted_at, task, taskId]);
 
@@ -281,7 +286,7 @@ export function AssignmentSubmissionOverlay({ taskId }: AssignmentSubmissionOver
   const handleGradeSubmission = () => {
     if (!parsedTask || parsedTask.taskType !== 'assignment' || !selectedSubmission?.uuid) return;
 
-    const maxScore = selectedSubmission.max_score ?? task?.max_points ?? 100;
+    const maxScore = selectedSubmission.max_score ?? assignmentTask?.max_points ?? 100;
     const numericScore = Number(score || selectedSubmission.score || 0);
 
     if (!Number.isFinite(numericScore)) {

--- a/services/client/@tanstack/react-query.gen.ts
+++ b/services/client/@tanstack/react-query.gen.ts
@@ -213,6 +213,8 @@ import {
   getAvailabilitySlots,
   createAvailabilitySlot,
   createLink,
+  sweep,
+  reconcile,
   enrollStudent,
   joinWaitlist,
   getAllCourses,
@@ -297,6 +299,7 @@ import {
   createClassDefinitionForProgramMultipart,
   listJobs,
   createJob,
+  uploadJobThumbnail,
   cancelJob,
   assignInstructor,
   listJobApplications,
@@ -431,6 +434,7 @@ import {
   searchDocuments,
   getStudentDashboard,
   getMyStudents,
+  getFile,
   cancelEnrollment,
   getEnrollment,
   getScheduledInstanceEnrollmentsForStudent,
@@ -444,7 +448,10 @@ import {
   listDocumentTypes,
   listCurrencies,
   getDefaultCurrency,
+  getCourseVersions,
   getStatusTransitions,
+  withdrawPendingEdit,
+  getPendingEdit,
   checkRubricAssociation,
   getPrimaryRubric,
   getRubricsByContext,
@@ -533,9 +540,11 @@ import {
   getOrganisationSupportedDomains,
   getDashboardStatistics,
   getDashboardActivity,
+  getCourseEditDiff,
   getCourseModerationHistory,
   getCourseApprovalStatus,
   listPendingCourses,
+  listPendingCourseEdits,
   clearInstructorAvailability,
   revokeLink,
   dissociateRubric,
@@ -1092,6 +1101,12 @@ import type {
   CreateLinkData,
   CreateLinkError,
   CreateLinkResponse,
+  SweepData,
+  SweepError,
+  SweepResponse,
+  ReconcileData,
+  ReconcileError,
+  ReconcileResponse,
   EnrollStudentData,
   EnrollStudentError,
   EnrollStudentResponse,
@@ -1326,6 +1341,9 @@ import type {
   CreateJobData,
   CreateJobError,
   CreateJobResponse,
+  UploadJobThumbnailData,
+  UploadJobThumbnailError,
+  UploadJobThumbnailResponse,
   CancelJobData,
   CancelJobError,
   CancelJobResponse,
@@ -1652,6 +1670,7 @@ import type {
   SearchDocumentsResponse,
   GetStudentDashboardData,
   GetMyStudentsData,
+  GetFileData,
   CancelEnrollmentData,
   CancelEnrollmentError,
   CancelEnrollmentResponse,
@@ -1679,7 +1698,14 @@ import type {
   ListCurrenciesError,
   ListCurrenciesResponse,
   GetDefaultCurrencyData,
+  GetCourseVersionsData,
+  GetCourseVersionsError,
+  GetCourseVersionsResponse,
   GetStatusTransitionsData,
+  WithdrawPendingEditData,
+  WithdrawPendingEditError,
+  WithdrawPendingEditResponse,
+  GetPendingEditData,
   CheckRubricAssociationData,
   GetPrimaryRubricData,
   GetRubricsByContextData,
@@ -1840,6 +1866,7 @@ import type {
   GetDashboardActivityData,
   GetDashboardActivityError,
   GetDashboardActivityResponse,
+  GetCourseEditDiffData,
   GetCourseModerationHistoryData,
   GetCourseModerationHistoryError,
   GetCourseModerationHistoryResponse,
@@ -1847,6 +1874,9 @@ import type {
   ListPendingCoursesData,
   ListPendingCoursesError,
   ListPendingCoursesResponse,
+  ListPendingCourseEditsData,
+  ListPendingCourseEditsError,
+  ListPendingCourseEditsResponse,
   ClearInstructorAvailabilityData,
   ClearInstructorAvailabilityError,
   ClearInstructorAvailabilityResponse,
@@ -9477,6 +9507,101 @@ export const createLinkMutation = (
   return mutationOptions;
 };
 
+export const sweepQueryKey = (options?: Options<SweepData>) => createQueryKey('sweep', options);
+
+/**
+ * Sweep for orphaned files
+ * Reports files on disk that no database reference or registry entry points to. With deleteOrphans=true, the orphaned files are removed from disk.
+ */
+export const sweepOptions = (options?: Options<SweepData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await sweep({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: sweepQueryKey(options),
+  });
+};
+
+/**
+ * Sweep for orphaned files
+ * Reports files on disk that no database reference or registry entry points to. With deleteOrphans=true, the orphaned files are removed from disk.
+ */
+export const sweepMutation = (
+  options?: Partial<Options<SweepData>>
+): UseMutationOptions<SweepResponse, SweepError, Options<SweepData>> => {
+  const mutationOptions: UseMutationOptions<SweepResponse, SweepError, Options<SweepData>> = {
+    mutationFn: async localOptions => {
+      const { data } = await sweep({
+        ...options,
+        ...localOptions,
+        throwOnError: true,
+      });
+      return data;
+    },
+  };
+  return mutationOptions;
+};
+
+export const reconcileQueryKey = (options?: Options<ReconcileData>) =>
+  createQueryKey('reconcile', options);
+
+/**
+ * Reconcile stored files with database references
+ * Cross-checks disk, the media_files registry and every domain file-reference column.
+ * Fills missing registry metadata and flags registry rows whose file is gone.
+ * With prune=true, domain references to lost files are cleared so API responses stop
+ * returning URLs that would 404 (users can then re-upload).
+ *
+ */
+export const reconcileOptions = (options?: Options<ReconcileData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await reconcile({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: reconcileQueryKey(options),
+  });
+};
+
+/**
+ * Reconcile stored files with database references
+ * Cross-checks disk, the media_files registry and every domain file-reference column.
+ * Fills missing registry metadata and flags registry rows whose file is gone.
+ * With prune=true, domain references to lost files are cleared so API responses stop
+ * returning URLs that would 404 (users can then re-upload).
+ *
+ */
+export const reconcileMutation = (
+  options?: Partial<Options<ReconcileData>>
+): UseMutationOptions<ReconcileResponse, ReconcileError, Options<ReconcileData>> => {
+  const mutationOptions: UseMutationOptions<
+    ReconcileResponse,
+    ReconcileError,
+    Options<ReconcileData>
+  > = {
+    mutationFn: async localOptions => {
+      const { data } = await reconcile({
+        ...options,
+        ...localOptions,
+        throwOnError: true,
+      });
+      return data;
+    },
+  };
+  return mutationOptions;
+};
+
 export const enrollStudentQueryKey = (options: Options<EnrollStudentData>) =>
   createQueryKey('enrollStudent', options);
 
@@ -14020,6 +14145,56 @@ export const createJobMutation = (
   return mutationOptions;
 };
 
+export const uploadJobThumbnailQueryKey = (options: Options<UploadJobThumbnailData>) =>
+  createQueryKey('uploadJobThumbnail', options);
+
+/**
+ * Upload a marketplace class job thumbnail
+ * Attaches a thumbnail image to an organisation's class advert. Returns the updated job with a resolved thumbnail_url.
+ */
+export const uploadJobThumbnailOptions = (options: Options<UploadJobThumbnailData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await uploadJobThumbnail({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: uploadJobThumbnailQueryKey(options),
+  });
+};
+
+/**
+ * Upload a marketplace class job thumbnail
+ * Attaches a thumbnail image to an organisation's class advert. Returns the updated job with a resolved thumbnail_url.
+ */
+export const uploadJobThumbnailMutation = (
+  options?: Partial<Options<UploadJobThumbnailData>>
+): UseMutationOptions<
+  UploadJobThumbnailResponse,
+  UploadJobThumbnailError,
+  Options<UploadJobThumbnailData>
+> => {
+  const mutationOptions: UseMutationOptions<
+    UploadJobThumbnailResponse,
+    UploadJobThumbnailError,
+    Options<UploadJobThumbnailData>
+  > = {
+    mutationFn: async localOptions => {
+      const { data } = await uploadJobThumbnail({
+        ...options,
+        ...localOptions,
+        throwOnError: true,
+      });
+      return data;
+    },
+  };
+  return mutationOptions;
+};
+
 export const cancelJobQueryKey = (options: Options<CancelJobData>) =>
   createQueryKey('cancelJob', options);
 
@@ -16045,7 +16220,19 @@ export const moderateCourseQueryKey = (options: Options<ModerateCourseData>) =>
   createQueryKey('moderateCourse', options);
 
 /**
- * Moderate course approval
+ * Moderate a course or its pending edit
+ * Applies a moderation decision to a course.
+ *
+ * **When the course has an edit awaiting review**, the decision applies to that
+ * edit: `approved` promotes the draft onto the live course and records a new
+ * version; `rejected` discards the draft and leaves the live course untouched,
+ * including its approval — the published content was never at fault.
+ *
+ * **Otherwise** the decision applies to the course's own approval state, as
+ * before: `approved` makes it available, `rejected`/`revoked` withdraw it.
+ *
+ * Every decision is recorded in the course's moderation history with its reason.
+ *
  */
 export const moderateCourseOptions = (options: Options<ModerateCourseData>) => {
   return queryOptions({
@@ -16063,7 +16250,19 @@ export const moderateCourseOptions = (options: Options<ModerateCourseData>) => {
 };
 
 /**
- * Moderate course approval
+ * Moderate a course or its pending edit
+ * Applies a moderation decision to a course.
+ *
+ * **When the course has an edit awaiting review**, the decision applies to that
+ * edit: `approved` promotes the draft onto the live course and records a new
+ * version; `rejected` discards the draft and leaves the live course untouched,
+ * including its approval — the published content was never at fault.
+ *
+ * **Otherwise** the decision applies to the course's own approval state, as
+ * before: `approved` makes it available, `rejected`/`revoked` withdraw it.
+ *
+ * Every decision is recorded in the course's moderation history with its reason.
+ *
  */
 export const moderateCourseMutation = (
   options?: Partial<Options<ModerateCourseData>>
@@ -20689,6 +20888,28 @@ export const getMyStudentsOptions = (options?: Options<GetMyStudentsData>) => {
   });
 };
 
+export const getFileQueryKey = (options: Options<GetFileData>) =>
+  createQueryKey('getFile', options);
+
+/**
+ * Get a stored file by its storage key
+ * Serves any stored file (images, videos, documents, certificates) by its canonical storage key.
+ */
+export const getFileOptions = (options: Options<GetFileData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await getFile({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: getFileQueryKey(options),
+  });
+};
+
 /**
  * Cancel a student enrollment
  */
@@ -21268,6 +21489,82 @@ export const getDefaultCurrencyOptions = (options?: Options<GetDefaultCurrencyDa
   });
 };
 
+export const getCourseVersionsQueryKey = (options: Options<GetCourseVersionsData>) =>
+  createQueryKey('getCourseVersions', options);
+
+/**
+ * Get this course's approved version history
+ * Returns each approved version of the course's content, newest first. A version
+ * is recorded every time an admin approves an edit and it is promoted onto the
+ * live course.
+ *
+ * **Authorization:** Only the course owner.
+ *
+ */
+export const getCourseVersionsOptions = (options: Options<GetCourseVersionsData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await getCourseVersions({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: getCourseVersionsQueryKey(options),
+  });
+};
+
+export const getCourseVersionsInfiniteQueryKey = (
+  options: Options<GetCourseVersionsData>
+): QueryKey<Options<GetCourseVersionsData>> => createQueryKey('getCourseVersions', options, true);
+
+/**
+ * Get this course's approved version history
+ * Returns each approved version of the course's content, newest first. A version
+ * is recorded every time an admin approves an edit and it is promoted onto the
+ * live course.
+ *
+ * **Authorization:** Only the course owner.
+ *
+ */
+export const getCourseVersionsInfiniteOptions = (options: Options<GetCourseVersionsData>) => {
+  return infiniteQueryOptions<
+    GetCourseVersionsResponse,
+    GetCourseVersionsError,
+    InfiniteData<GetCourseVersionsResponse>,
+    QueryKey<Options<GetCourseVersionsData>>,
+    | number
+    | Pick<QueryKey<Options<GetCourseVersionsData>>[0], 'body' | 'headers' | 'path' | 'query'>
+  >(
+    {
+      queryFn: async ({ pageParam, queryKey, signal }) => {
+        const page: Pick<
+          QueryKey<Options<GetCourseVersionsData>>[0],
+          'body' | 'headers' | 'path' | 'query'
+        > =
+          typeof pageParam === 'object'
+            ? pageParam
+            : {
+                query: {
+                  pageable: { page: pageParam },
+                },
+              };
+        const params = createInfiniteParams(queryKey, page);
+        const { data } = await getCourseVersions({
+          ...options,
+          ...params,
+          signal,
+          throwOnError: true,
+        });
+        return data;
+      },
+      queryKey: getCourseVersionsInfiniteQueryKey(options),
+    }
+  );
+};
+
 export const getStatusTransitionsQueryKey = (options: Options<GetStatusTransitionsData>) =>
   createQueryKey('getStatusTransitions', options);
 
@@ -21294,6 +21591,67 @@ export const getStatusTransitionsOptions = (options: Options<GetStatusTransition
       return data;
     },
     queryKey: getStatusTransitionsQueryKey(options),
+  });
+};
+
+/**
+ * Withdraw this course's pending edit
+ * Abandons the edit awaiting review and discards the draft. The live course is
+ * not affected — it was never modified while the edit was pending.
+ *
+ * **Authorization:** Only the course owner.
+ *
+ */
+export const withdrawPendingEditMutation = (
+  options?: Partial<Options<WithdrawPendingEditData>>
+): UseMutationOptions<
+  WithdrawPendingEditResponse,
+  WithdrawPendingEditError,
+  Options<WithdrawPendingEditData>
+> => {
+  const mutationOptions: UseMutationOptions<
+    WithdrawPendingEditResponse,
+    WithdrawPendingEditError,
+    Options<WithdrawPendingEditData>
+  > = {
+    mutationFn: async localOptions => {
+      const { data } = await withdrawPendingEdit({
+        ...options,
+        ...localOptions,
+        throwOnError: true,
+      });
+      return data;
+    },
+  };
+  return mutationOptions;
+};
+
+export const getPendingEditQueryKey = (options: Options<GetPendingEditData>) =>
+  createQueryKey('getPendingEdit', options);
+
+/**
+ * Get this course's pending edit
+ * Returns the edit awaiting admin review for this course, if there is one.
+ *
+ * While an edit is pending the course stays published and keeps serving its
+ * last-approved content to learners. The proposed content lives on the draft
+ * course referenced by `draft_course_uuid`, which only the course owner can see.
+ *
+ * **Authorization:** Only the course owner.
+ *
+ */
+export const getPendingEditOptions = (options: Options<GetPendingEditData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await getPendingEdit({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: getPendingEditQueryKey(options),
   });
 };
 
@@ -25180,6 +25538,30 @@ export const getDashboardActivityInfiniteOptions = (options: Options<GetDashboar
   );
 };
 
+export const getCourseEditDiffQueryKey = (options: Options<GetCourseEditDiffData>) =>
+  createQueryKey('getCourseEditDiff', options);
+
+/**
+ * Show what a pending edit would change
+ * The difference between the live course and the edit awaiting review: which
+ * course fields change and how many lessons the edit adds, removes or modifies.
+ *
+ */
+export const getCourseEditDiffOptions = (options: Options<GetCourseEditDiffData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await getCourseEditDiff({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: getCourseEditDiffQueryKey(options),
+  });
+};
+
 export const getCourseModerationHistoryQueryKey = (
   options: Options<GetCourseModerationHistoryData>
 ) => createQueryKey('getCourseModerationHistory', options);
@@ -25278,7 +25660,13 @@ export const listPendingCoursesQueryKey = (options: Options<ListPendingCoursesDa
   createQueryKey('listPendingCourses', options);
 
 /**
- * List courses pending approval
+ * List courses pending first approval
+ * Courses that have never been approved and are waiting on an initial decision.
+ *
+ * This does **not** include already-published courses with a pending edit: those
+ * keep `admin_approved = true` while their edit is reviewed, so they never match
+ * this query. Use `GET /api/v1/admin/courses/pending-edits` for those.
+ *
  */
 export const listPendingCoursesOptions = (options: Options<ListPendingCoursesData>) => {
   return queryOptions({
@@ -25300,7 +25688,13 @@ export const listPendingCoursesInfiniteQueryKey = (
 ): QueryKey<Options<ListPendingCoursesData>> => createQueryKey('listPendingCourses', options, true);
 
 /**
- * List courses pending approval
+ * List courses pending first approval
+ * Courses that have never been approved and are waiting on an initial decision.
+ *
+ * This does **not** include already-published courses with a pending edit: those
+ * keep `admin_approved = true` while their edit is reviewed, so they never match
+ * this query. Use `GET /api/v1/admin/courses/pending-edits` for those.
+ *
  */
 export const listPendingCoursesInfiniteOptions = (options: Options<ListPendingCoursesData>) => {
   return infiniteQueryOptions<
@@ -25334,6 +25728,87 @@ export const listPendingCoursesInfiniteOptions = (options: Options<ListPendingCo
         return data;
       },
       queryKey: listPendingCoursesInfiniteQueryKey(options),
+    }
+  );
+};
+
+export const listPendingCourseEditsQueryKey = (options: Options<ListPendingCourseEditsData>) =>
+  createQueryKey('listPendingCourseEdits', options);
+
+/**
+ * List edits to published courses awaiting review
+ * Edits submitted against already-published courses, newest first.
+ *
+ * Each of these courses is still live and serving its last-approved content —
+ * the proposed change is held on a draft and is invisible to learners until
+ * approved. Approving promotes the draft onto the live course; rejecting
+ * discards it and leaves the live course exactly as it was.
+ *
+ */
+export const listPendingCourseEditsOptions = (options: Options<ListPendingCourseEditsData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await listPendingCourseEdits({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: listPendingCourseEditsQueryKey(options),
+  });
+};
+
+export const listPendingCourseEditsInfiniteQueryKey = (
+  options: Options<ListPendingCourseEditsData>
+): QueryKey<Options<ListPendingCourseEditsData>> =>
+  createQueryKey('listPendingCourseEdits', options, true);
+
+/**
+ * List edits to published courses awaiting review
+ * Edits submitted against already-published courses, newest first.
+ *
+ * Each of these courses is still live and serving its last-approved content —
+ * the proposed change is held on a draft and is invisible to learners until
+ * approved. Approving promotes the draft onto the live course; rejecting
+ * discards it and leaves the live course exactly as it was.
+ *
+ */
+export const listPendingCourseEditsInfiniteOptions = (
+  options: Options<ListPendingCourseEditsData>
+) => {
+  return infiniteQueryOptions<
+    ListPendingCourseEditsResponse,
+    ListPendingCourseEditsError,
+    InfiniteData<ListPendingCourseEditsResponse>,
+    QueryKey<Options<ListPendingCourseEditsData>>,
+    | number
+    | Pick<QueryKey<Options<ListPendingCourseEditsData>>[0], 'body' | 'headers' | 'path' | 'query'>
+  >(
+    {
+      queryFn: async ({ pageParam, queryKey, signal }) => {
+        const page: Pick<
+          QueryKey<Options<ListPendingCourseEditsData>>[0],
+          'body' | 'headers' | 'path' | 'query'
+        > =
+          typeof pageParam === 'object'
+            ? pageParam
+            : {
+                query: {
+                  pageable: { page: pageParam },
+                },
+              };
+        const params = createInfiniteParams(queryKey, page);
+        const { data } = await listPendingCourseEdits({
+          ...options,
+          ...params,
+          signal,
+          throwOnError: true,
+        });
+        return data;
+      },
+      queryKey: listPendingCourseEditsInfiniteQueryKey(options),
     }
   );
 };

--- a/services/client/schemas.gen.ts
+++ b/services/client/schemas.gen.ts
@@ -3297,17 +3297,6 @@ export const InstructorProfessionalMembershipSchema = {
       example: '4 years, 3 months',
       readOnly: true,
     },
-    membership_duration_months: {
-      type: ['integer', 'null'],
-      format: 'int32',
-      description:
-        '**[READ-ONLY]** Duration of membership calculated from start and end dates, in months.',
-      example: 51,
-      readOnly: true,
-    },
-    membership_status: {
-      $ref: '#/components/schemas/MembershipStatusEnum',
-    },
     membership_period: {
       type: ['string', 'null'],
       description: '**[READ-ONLY]** Formatted membership period showing start and end dates.',
@@ -3344,6 +3333,17 @@ export const InstructorProfessionalMembershipSchema = {
         '**[READ-ONLY]** Indicates if this membership was started within the last 3 years.',
       example: true,
       readOnly: true,
+    },
+    membership_duration_months: {
+      type: ['integer', 'null'],
+      format: 'int32',
+      description:
+        '**[READ-ONLY]** Duration of membership calculated from start and end dates, in months.',
+      example: 51,
+      readOnly: true,
+    },
+    membership_status: {
+      $ref: '#/components/schemas/MembershipStatusEnum',
     },
     is_valid: {
       type: 'boolean',
@@ -8269,6 +8269,11 @@ export const ClassMarketplaceJobSchema = {
       type: 'string',
       readOnly: true,
     },
+    thumbnail_url: {
+      type: 'string',
+      description: 'Public URL to the class advert thumbnail image, if uploaded.',
+      readOnly: true,
+    },
     location_type: {
       $ref: '#/components/schemas/LocationTypeEnum',
     },
@@ -10086,6 +10091,116 @@ export const GuardianStudentLinkRequestSchema = {
     },
   },
   required: ['guardianUserUuid', 'relationshipType', 'shareScope', 'studentUuid'],
+} as const;
+
+export const ApiResponseSweepReportSchema = {
+  type: 'object',
+  properties: {
+    success: {
+      type: 'boolean',
+    },
+    data: {
+      $ref: '#/components/schemas/SweepReport',
+    },
+    message: {
+      type: 'string',
+    },
+    error: {},
+  },
+} as const;
+
+export const SweepReportSchema = {
+  type: 'object',
+  properties: {
+    diskFiles: {
+      type: 'integer',
+      format: 'int32',
+    },
+    referencedKeys: {
+      type: 'integer',
+      format: 'int32',
+    },
+    orphanKeys: {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+    },
+    orphansDeleted: {
+      type: 'integer',
+      format: 'int32',
+    },
+  },
+} as const;
+
+export const ApiResponseReconcileReportSchema = {
+  type: 'object',
+  properties: {
+    success: {
+      type: 'boolean',
+    },
+    data: {
+      $ref: '#/components/schemas/ReconcileReport',
+    },
+    message: {
+      type: 'string',
+    },
+    error: {},
+  },
+} as const;
+
+export const DeadReferenceSchema = {
+  type: 'object',
+  properties: {
+    table: {
+      type: 'string',
+    },
+    column: {
+      type: 'string',
+    },
+    rowUuid: {
+      type: 'string',
+      format: 'uuid',
+    },
+    value: {
+      type: 'string',
+    },
+    nullable: {
+      type: 'boolean',
+    },
+  },
+} as const;
+
+export const ReconcileReportSchema = {
+  type: 'object',
+  properties: {
+    registryRowsChecked: {
+      type: 'integer',
+      format: 'int32',
+    },
+    registryMarkedMissing: {
+      type: 'integer',
+      format: 'int32',
+    },
+    registryMetadataFilled: {
+      type: 'integer',
+      format: 'int32',
+    },
+    deadReferences: {
+      type: 'array',
+      items: {
+        $ref: '#/components/schemas/DeadReference',
+      },
+    },
+    deadReferencesPruned: {
+      type: 'integer',
+      format: 'int32',
+    },
+    orphanRowsDeleted: {
+      type: 'integer',
+      format: 'int32',
+    },
+  },
 } as const;
 
 export const EnrollmentRequestSchema = {
@@ -12412,6 +12527,33 @@ export const AdminCreateUserRequestDTOSchema = {
   required: ['email', 'first_name', 'last_name'],
 } as const;
 
+export const ContentModerationDecisionRequestSchema = {
+  type: 'object',
+  description: `Payload for a moderation decision on a course or training program.
+
+When the content has a pending edit awaiting review, \`approved\` promotes that
+edit onto the live content and \`rejected\` discards it, leaving the live content
+untouched. Otherwise the decision applies to the content's own approval state.
+`,
+  example: {
+    action: 'rejected',
+    reason: 'Lesson 3 video is missing captions.',
+  },
+  properties: {
+    action: {
+      $ref: '#/components/schemas/ActionEnum',
+    },
+    reason: {
+      type: ['string', 'null'],
+      description:
+        'Reason for the decision. Shown to the course creator and retained in the moderation history.',
+      maxLength: 2000,
+      minLength: 0,
+    },
+  },
+  required: ['action'],
+} as const;
+
 export const OrganisationUserCreateRequestDTOSchema = {
   type: 'object',
   properties: {
@@ -13173,10 +13315,10 @@ export const PageableObjectSchema = {
 export const SortObjectSchema = {
   type: 'object',
   properties: {
-    sorted: {
+    unsorted: {
       type: 'boolean',
     },
-    unsorted: {
+    sorted: {
       type: 'boolean',
     },
     empty: {
@@ -16168,6 +16310,101 @@ export const PagedDTOCourseSchema = {
   },
 } as const;
 
+export const ApiResponsePagedDTOCourseVersionSnapshotSchema = {
+  type: 'object',
+  properties: {
+    success: {
+      type: 'boolean',
+    },
+    data: {
+      $ref: '#/components/schemas/PagedDTOCourseVersionSnapshot',
+    },
+    message: {
+      type: 'string',
+    },
+    error: {},
+  },
+} as const;
+
+export const CourseVersionSnapshotSchema = {
+  type: 'object',
+  description: `An approved version of a course's content. One is written each time an edit is
+promoted onto the live course, giving a durable record of what the course
+looked like at each approved version.
+`,
+  example: {
+    uuid: 'snap-1234-5678-90ab-cdef12345678',
+    course_uuid: 'course-1234-5678-90ab-cdef12345678',
+    version_number: 3,
+    pending_edit_uuid: 'edit-1234-5678-90ab-cdef12345678',
+    created_date: '2026-07-17T11:30:00',
+    created_by: 'admin@example.com',
+  },
+  properties: {
+    uuid: {
+      type: 'string',
+      format: 'uuid',
+      description: '**[READ-ONLY]** Unique identifier for the snapshot.',
+      readOnly: true,
+    },
+    snapshot: {
+      $ref: '#/components/schemas/JsonNode',
+      description:
+        '**[READ-ONLY]** Full course tree at this version: course fields, category uuids, lessons and their content.',
+      readOnly: true,
+    },
+    course_uuid: {
+      type: 'string',
+      format: 'uuid',
+      description: '**[READ-ONLY]** The course this version belongs to.',
+      readOnly: true,
+    },
+    version_number: {
+      type: 'integer',
+      format: 'int32',
+      description: '**[READ-ONLY]** Monotonic version number, starting at 1.',
+      example: 3,
+      readOnly: true,
+    },
+    pending_edit_uuid: {
+      type: 'string',
+      format: 'uuid',
+      description: '**[READ-ONLY]** The edit whose promotion produced this version, if any.',
+      readOnly: true,
+    },
+    created_date: {
+      type: 'string',
+      format: 'date-time',
+      description: '**[READ-ONLY]** When this version became live.',
+      readOnly: true,
+    },
+    created_by: {
+      type: 'string',
+      description: '**[READ-ONLY]** Who promoted this version.',
+      example: 'admin@example.com',
+      readOnly: true,
+    },
+  },
+} as const;
+
+export const PagedDTOCourseVersionSnapshotSchema = {
+  type: 'object',
+  properties: {
+    content: {
+      type: 'array',
+      items: {
+        $ref: '#/components/schemas/CourseVersionSnapshot',
+      },
+    },
+    metadata: {
+      $ref: '#/components/schemas/PageMetadata',
+    },
+    links: {
+      $ref: '#/components/schemas/PageLinks',
+    },
+  },
+} as const;
+
 export const ApiResponseListContentStatusSchema = {
   type: 'object',
   properties: {
@@ -16184,6 +16421,105 @@ export const ApiResponseListContentStatusSchema = {
       type: 'string',
     },
     error: {},
+  },
+} as const;
+
+export const ApiResponseCoursePendingEditSchema = {
+  type: 'object',
+  properties: {
+    success: {
+      type: 'boolean',
+    },
+    data: {
+      $ref: '#/components/schemas/CoursePendingEdit',
+    },
+    message: {
+      type: 'string',
+    },
+    error: {},
+  },
+} as const;
+
+export const CoursePendingEditSchema = {
+  type: 'object',
+  description: `An edit to a published course that is awaiting admin review.
+
+The live course is unaffected while the edit is pending: it stays published,
+keeps accepting enrollments, and continues to serve its last-approved content.
+The proposed content lives on the draft course referenced by \`draft_course_uuid\`.
+`,
+  example: {
+    uuid: 'edit-1234-5678-90ab-cdef12345678',
+    course_uuid: 'course-1234-5678-90ab-cdef12345678',
+    draft_course_uuid: 'draft-1234-5678-90ab-cdef12345678',
+    status: 'pending',
+    submitted_by_uuid: 'user-1234-5678-90ab-cdef12345678',
+    submitted_at: '2026-07-17T09:00:00',
+    reviewed_by_uuid: null,
+    reviewed_at: null,
+    review_reason: null,
+  },
+  properties: {
+    uuid: {
+      type: 'string',
+      format: 'uuid',
+      description: '**[READ-ONLY]** Unique identifier for the pending edit.',
+      example: 'edit-1234-5678-90ab-cdef12345678',
+      readOnly: true,
+    },
+    status: {
+      $ref: '#/components/schemas/StatusEnum19',
+    },
+    course_uuid: {
+      type: 'string',
+      format: 'uuid',
+      description: '**[READ-ONLY]** The live course this edit applies to.',
+      example: 'course-1234-5678-90ab-cdef12345678',
+      readOnly: true,
+    },
+    draft_course_uuid: {
+      type: 'string',
+      format: 'uuid',
+      description:
+        '**[READ-ONLY]** Draft course holding the proposed content. Null once the edit is resolved.',
+      example: 'draft-1234-5678-90ab-cdef12345678',
+      readOnly: true,
+    },
+    submitted_by_uuid: {
+      type: 'string',
+      format: 'uuid',
+      description:
+        '**[READ-ONLY]** Internal user UUID of the course creator who submitted the edit.',
+      example: 'user-1234-5678-90ab-cdef12345678',
+      readOnly: true,
+    },
+    submitted_at: {
+      type: 'string',
+      format: 'date-time',
+      description: '**[READ-ONLY]** When the edit was submitted for review.',
+      example: '2026-07-17T09:00:00',
+      readOnly: true,
+    },
+    reviewed_by_uuid: {
+      type: 'string',
+      format: 'uuid',
+      description: '**[READ-ONLY]** Internal user UUID of the admin who reviewed the edit.',
+      example: 'user-9999-5678-90ab-cdef12345678',
+      readOnly: true,
+    },
+    reviewed_at: {
+      type: 'string',
+      format: 'date-time',
+      description: '**[READ-ONLY]** When the edit was reviewed.',
+      example: '2026-07-17T11:30:00',
+      readOnly: true,
+    },
+    review_reason: {
+      type: 'string',
+      description: '**[READ-ONLY]** Reason the admin gave for their decision.',
+      example: 'Pricing change is not justified.',
+      readOnly: true,
+    },
   },
 } as const;
 
@@ -18872,6 +19208,151 @@ export const ApiResponseListCurrencySchema = {
   },
 } as const;
 
+export const ApiResponseCourseEditDiffSchema = {
+  type: 'object',
+  properties: {
+    success: {
+      type: 'boolean',
+    },
+    data: {
+      $ref: '#/components/schemas/CourseEditDiff',
+    },
+    message: {
+      type: 'string',
+    },
+    error: {},
+  },
+} as const;
+
+export const CourseEditDiffSchema = {
+  type: 'object',
+  description: `What a pending edit would change if approved, so an admin can review the
+decision without comparing two full course payloads by eye.
+`,
+  example: {
+    course_uuid: 'course-1234-5678-90ab-cdef12345678',
+    draft_course_uuid: 'draft-1234-5678-90ab-cdef12345678',
+    field_changes: [
+      {
+        field: 'name',
+        live_value: 'Intro to Piano',
+        draft_value: 'Introduction to Piano',
+      },
+      {
+        field: 'price',
+        live_value: '1500.00',
+        draft_value: '1800.00',
+      },
+    ],
+    lessons_added: 1,
+    lessons_removed: 0,
+    lessons_modified: 2,
+  },
+  properties: {
+    course_uuid: {
+      type: 'string',
+      format: 'uuid',
+      description: '**[READ-ONLY]** The live course under review.',
+      readOnly: true,
+    },
+    draft_course_uuid: {
+      type: 'string',
+      format: 'uuid',
+      description: '**[READ-ONLY]** Draft course holding the proposed content.',
+      readOnly: true,
+    },
+    field_changes: {
+      type: 'array',
+      description:
+        '**[READ-ONLY]** Course fields that differ between the live course and the draft.',
+      items: {
+        $ref: '#/components/schemas/CourseEditFieldChange',
+      },
+      readOnly: true,
+    },
+    lessons_added: {
+      type: 'integer',
+      format: 'int32',
+      description: '**[READ-ONLY]** Lessons the edit adds.',
+      example: 1,
+      readOnly: true,
+    },
+    lessons_removed: {
+      type: 'integer',
+      format: 'int32',
+      description: '**[READ-ONLY]** Lessons the edit removes.',
+      example: 0,
+      readOnly: true,
+    },
+    lessons_modified: {
+      type: 'integer',
+      format: 'int32',
+      description: '**[READ-ONLY]** Lessons the edit changes in place.',
+      example: 2,
+      readOnly: true,
+    },
+  },
+} as const;
+
+export const CourseEditFieldChangeSchema = {
+  type: 'object',
+  description: 'A single course field the edit would change.',
+  properties: {
+    field: {
+      type: 'string',
+      description: '**[READ-ONLY]** Field name, in snake_case as it appears on the course payload.',
+      example: 'price',
+      readOnly: true,
+    },
+    live_value: {
+      type: 'string',
+      description: '**[READ-ONLY]** Current value on the live course, rendered as text.',
+      example: '1500.00',
+      readOnly: true,
+    },
+    draft_value: {
+      type: 'string',
+      description: '**[READ-ONLY]** Proposed value on the draft, rendered as text.',
+      example: '1800.00',
+      readOnly: true,
+    },
+  },
+} as const;
+
+export const ApiResponsePagedDTOCoursePendingEditSchema = {
+  type: 'object',
+  properties: {
+    success: {
+      type: 'boolean',
+    },
+    data: {
+      $ref: '#/components/schemas/PagedDTOCoursePendingEdit',
+    },
+    message: {
+      type: 'string',
+    },
+    error: {},
+  },
+} as const;
+
+export const PagedDTOCoursePendingEditSchema = {
+  type: 'object',
+  properties: {
+    content: {
+      type: 'array',
+      items: {
+        $ref: '#/components/schemas/CoursePendingEdit',
+      },
+    },
+    metadata: {
+      $ref: '#/components/schemas/PageMetadata',
+    },
+    links: {
+      $ref: '#/components/schemas/PageLinks',
+    },
+  },
+} as const;
+
 export const AfricanPhoneNumberSchema = {
   format: 'phone',
   description: 'Valid African phone number in international or local format',
@@ -19115,14 +19596,6 @@ export const ProficiencyLevelEnumSchema = {
   example: 'EXPERT',
 } as const;
 
-export const MembershipStatusEnumSchema = {
-  type: 'string',
-  description: '**[READ-ONLY]** Current status of the membership.',
-  enum: ['ACTIVE', 'INACTIVE', 'EXPIRED', 'UNKNOWN'],
-  example: 'ACTIVE',
-  readOnly: true,
-} as const;
-
 export const OrganisationTypeEnumSchema = {
   type: 'string',
   description: '**[READ-ONLY]** Classification of organisation type based on name keywords.',
@@ -19135,6 +19608,14 @@ export const OrganisationTypeEnumSchema = {
     'OTHER',
   ],
   example: 'PROFESSIONAL_INSTITUTE',
+  readOnly: true,
+} as const;
+
+export const MembershipStatusEnumSchema = {
+  type: 'string',
+  description: '**[READ-ONLY]** Current status of the membership.',
+  enum: ['ACTIVE', 'INACTIVE', 'EXPIRED', 'UNKNOWN'],
+  example: 'ACTIVE',
   readOnly: true,
 } as const;
 
@@ -19479,6 +19960,12 @@ export const AssignmentTypeEnumSchema = {
   minLength: 1,
 } as const;
 
+export const ActionEnumSchema = {
+  type: 'string',
+  description: 'The decision to apply.',
+  enum: ['approved', 'rejected', 'revoked'],
+} as const;
+
 export const DomainNameEnum2Schema = {
   type: 'string',
   description: 'Domain/role to assign within the organisation',
@@ -19563,11 +20050,11 @@ export const EntryTypeEnum2Schema = {
   example: 'SCHEDULED_INSTANCE',
 } as const;
 
-export const ActionEnumSchema = {
+export const StatusEnum19Schema = {
   type: 'string',
-  description: '**[READ-ONLY]** Moderation decision taken.',
-  enum: ['approved', 'rejected', 'revoked'],
-  example: 'rejected',
+  description: '**[READ-ONLY]** Review state of the edit.',
+  enum: ['pending', 'approved', 'rejected', 'withdrawn'],
+  example: 'pending',
   readOnly: true,
 } as const;
 
@@ -20067,6 +20554,12 @@ export const AssignmentTypeEnumWritableSchema = {
   enum: ['global', 'organization'],
   example: 'global',
   minLength: 1,
+} as const;
+
+export const ActionEnumWritableSchema = {
+  type: 'string',
+  description: 'The decision to apply.',
+  enum: ['approved', 'rejected', 'revoked'],
 } as const;
 
 export const DomainNameEnum2WritableSchema = {

--- a/services/client/sdk.gen.ts
+++ b/services/client/sdk.gen.ts
@@ -637,6 +637,12 @@ import type {
   CreateLinkData,
   CreateLinkResponses,
   CreateLinkErrors,
+  SweepData,
+  SweepResponses,
+  SweepErrors,
+  ReconcileData,
+  ReconcileResponses,
+  ReconcileErrors,
   EnrollStudentData,
   EnrollStudentResponses,
   EnrollStudentErrors,
@@ -889,6 +895,9 @@ import type {
   CreateJobData,
   CreateJobResponses,
   CreateJobErrors,
+  UploadJobThumbnailData,
+  UploadJobThumbnailResponses,
+  UploadJobThumbnailErrors,
   CancelJobData,
   CancelJobResponses,
   CancelJobErrors,
@@ -1291,6 +1300,9 @@ import type {
   GetMyStudentsData,
   GetMyStudentsResponses,
   GetMyStudentsErrors,
+  GetFileData,
+  GetFileResponses,
+  GetFileErrors,
   CancelEnrollmentData,
   CancelEnrollmentResponses,
   CancelEnrollmentErrors,
@@ -1330,9 +1342,18 @@ import type {
   GetDefaultCurrencyData,
   GetDefaultCurrencyResponses,
   GetDefaultCurrencyErrors,
+  GetCourseVersionsData,
+  GetCourseVersionsResponses,
+  GetCourseVersionsErrors,
   GetStatusTransitionsData,
   GetStatusTransitionsResponses,
   GetStatusTransitionsErrors,
+  WithdrawPendingEditData,
+  WithdrawPendingEditResponses,
+  WithdrawPendingEditErrors,
+  GetPendingEditData,
+  GetPendingEditResponses,
+  GetPendingEditErrors,
   CheckRubricAssociationData,
   CheckRubricAssociationResponses,
   CheckRubricAssociationErrors,
@@ -1597,6 +1618,9 @@ import type {
   GetDashboardActivityData,
   GetDashboardActivityResponses,
   GetDashboardActivityErrors,
+  GetCourseEditDiffData,
+  GetCourseEditDiffResponses,
+  GetCourseEditDiffErrors,
   GetCourseModerationHistoryData,
   GetCourseModerationHistoryResponses,
   GetCourseModerationHistoryErrors,
@@ -1606,6 +1630,9 @@ import type {
   ListPendingCoursesData,
   ListPendingCoursesResponses,
   ListPendingCoursesErrors,
+  ListPendingCourseEditsData,
+  ListPendingCourseEditsResponses,
+  ListPendingCourseEditsErrors,
   ClearInstructorAvailabilityData,
   ClearInstructorAvailabilityResponses,
   ClearInstructorAvailabilityErrors,
@@ -1868,6 +1895,7 @@ import {
   createClassDefinitionForProgramMultipartResponseTransformer,
   listJobsResponseTransformer,
   createJobResponseTransformer,
+  uploadJobThumbnailResponseTransformer,
   cancelJobResponseTransformer,
   assignInstructorResponseTransformer,
   listJobApplicationsResponseTransformer,
@@ -1983,6 +2011,9 @@ import {
   getEnrollmentsForInstanceResponseTransformer,
   getEnrollmentCountResponseTransformer,
   listCurrenciesResponseTransformer,
+  getCourseVersionsResponseTransformer,
+  withdrawPendingEditResponseTransformer,
+  getPendingEditResponseTransformer,
   getPrimaryRubricResponseTransformer,
   getRubricsByContextResponseTransformer,
   getEnrollmentGradeBookResponseTransformer,
@@ -2050,6 +2081,7 @@ import {
   getDashboardActivityResponseTransformer,
   getCourseModerationHistoryResponseTransformer,
   listPendingCoursesResponseTransformer,
+  listPendingCourseEditsResponseTransformer,
   removeItemResponseTransformer,
   removeAdminDomainResponseTransformer,
 } from './transformers.gen';
@@ -8293,6 +8325,58 @@ export const createLink = <ThrowOnError extends boolean = false>(
 };
 
 /**
+ * Sweep for orphaned files
+ * Reports files on disk that no database reference or registry entry points to. With deleteOrphans=true, the orphaned files are removed from disk.
+ */
+export const sweep = <ThrowOnError extends boolean = false>(
+  options?: Options<SweepData, ThrowOnError>
+) => {
+  return (options?.client ?? _heyApiClient).post<SweepResponses, SweepErrors, ThrowOnError>({
+    security: [
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+    ],
+    url: '/api/v1/files/admin/sweep',
+    ...options,
+  });
+};
+
+/**
+ * Reconcile stored files with database references
+ * Cross-checks disk, the media_files registry and every domain file-reference column.
+ * Fills missing registry metadata and flags registry rows whose file is gone.
+ * With prune=true, domain references to lost files are cleared so API responses stop
+ * returning URLs that would 404 (users can then re-upload).
+ *
+ */
+export const reconcile = <ThrowOnError extends boolean = false>(
+  options?: Options<ReconcileData, ThrowOnError>
+) => {
+  return (options?.client ?? _heyApiClient).post<ReconcileResponses, ReconcileErrors, ThrowOnError>(
+    {
+      security: [
+        {
+          scheme: 'bearer',
+          type: 'http',
+        },
+        {
+          scheme: 'bearer',
+          type: 'http',
+        },
+      ],
+      url: '/api/v1/files/admin/reconcile',
+      ...options,
+    }
+  );
+};
+
+/**
  * Enroll a student into a class across all scheduled instances
  */
 export const enrollStudent = <ThrowOnError extends boolean = false>(
@@ -10934,6 +11018,39 @@ export const createJob = <ThrowOnError extends boolean = false>(
 };
 
 /**
+ * Upload a marketplace class job thumbnail
+ * Attaches a thumbnail image to an organisation's class advert. Returns the updated job with a resolved thumbnail_url.
+ */
+export const uploadJobThumbnail = <ThrowOnError extends boolean = false>(
+  options: Options<UploadJobThumbnailData, ThrowOnError>
+) => {
+  return (options.client ?? _heyApiClient).post<
+    UploadJobThumbnailResponses,
+    UploadJobThumbnailErrors,
+    ThrowOnError
+  >({
+    ...formDataBodySerializer,
+    responseTransformer: uploadJobThumbnailResponseTransformer,
+    security: [
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+    ],
+    url: '/api/v1/classes/jobs/{uuid}/thumbnail',
+    ...options,
+    headers: {
+      'Content-Type': null,
+      ...options.headers,
+    },
+  });
+};
+
+/**
  * Cancel a marketplace class job
  */
 export const cancelJob = <ThrowOnError extends boolean = false>(
@@ -11858,6 +11975,10 @@ export const moderateProgram = <ThrowOnError extends boolean = false>(
     ],
     url: '/api/v1/admin/programs/{uuid}/moderate',
     ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
   });
 };
 
@@ -12104,7 +12225,19 @@ export const activate = <ThrowOnError extends boolean = false>(
 };
 
 /**
- * Moderate course approval
+ * Moderate a course or its pending edit
+ * Applies a moderation decision to a course.
+ *
+ * **When the course has an edit awaiting review**, the decision applies to that
+ * edit: `approved` promotes the draft onto the live course and records a new
+ * version; `rejected` discards the draft and leaves the live course untouched,
+ * including its approval — the published content was never at fault.
+ *
+ * **Otherwise** the decision applies to the course's own approval state, as
+ * before: `approved` makes it available, `rejected`/`revoked` withdraw it.
+ *
+ * Every decision is recorded in the course's moderation history with its reason.
+ *
  */
 export const moderateCourse = <ThrowOnError extends boolean = false>(
   options: Options<ModerateCourseData, ThrowOnError>
@@ -12127,6 +12260,10 @@ export const moderateCourse = <ThrowOnError extends boolean = false>(
     ],
     url: '/api/v1/admin/courses/{uuid}/moderate',
     ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
   });
 };
 
@@ -14888,6 +15025,29 @@ export const getMyStudents = <ThrowOnError extends boolean = false>(
 };
 
 /**
+ * Get a stored file by its storage key
+ * Serves any stored file (images, videos, documents, certificates) by its canonical storage key.
+ */
+export const getFile = <ThrowOnError extends boolean = false>(
+  options: Options<GetFileData, ThrowOnError>
+) => {
+  return (options.client ?? _heyApiClient).get<GetFileResponses, GetFileErrors, ThrowOnError>({
+    security: [
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+    ],
+    url: '/api/v1/files/{key}',
+    ...options,
+  });
+};
+
+/**
  * Cancel a student enrollment
  */
 export const cancelEnrollment = <ThrowOnError extends boolean = false>(
@@ -15237,6 +15397,39 @@ export const getDefaultCurrency = <ThrowOnError extends boolean = false>(
 };
 
 /**
+ * Get this course's approved version history
+ * Returns each approved version of the course's content, newest first. A version
+ * is recorded every time an admin approves an edit and it is promoted onto the
+ * live course.
+ *
+ * **Authorization:** Only the course owner.
+ *
+ */
+export const getCourseVersions = <ThrowOnError extends boolean = false>(
+  options: Options<GetCourseVersionsData, ThrowOnError>
+) => {
+  return (options.client ?? _heyApiClient).get<
+    GetCourseVersionsResponses,
+    GetCourseVersionsErrors,
+    ThrowOnError
+  >({
+    responseTransformer: getCourseVersionsResponseTransformer,
+    security: [
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+    ],
+    url: '/api/v1/courses/{uuid}/versions',
+    ...options,
+  });
+};
+
+/**
  * Get available status transitions
  * Returns the list of valid status transitions for a course based on its current state and business rules.
  *
@@ -15266,6 +15459,73 @@ export const getStatusTransitions = <ThrowOnError extends boolean = false>(
       },
     ],
     url: '/api/v1/courses/{uuid}/status-transitions',
+    ...options,
+  });
+};
+
+/**
+ * Withdraw this course's pending edit
+ * Abandons the edit awaiting review and discards the draft. The live course is
+ * not affected — it was never modified while the edit was pending.
+ *
+ * **Authorization:** Only the course owner.
+ *
+ */
+export const withdrawPendingEdit = <ThrowOnError extends boolean = false>(
+  options: Options<WithdrawPendingEditData, ThrowOnError>
+) => {
+  return (options.client ?? _heyApiClient).delete<
+    WithdrawPendingEditResponses,
+    WithdrawPendingEditErrors,
+    ThrowOnError
+  >({
+    responseTransformer: withdrawPendingEditResponseTransformer,
+    security: [
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+    ],
+    url: '/api/v1/courses/{uuid}/pending-edit',
+    ...options,
+  });
+};
+
+/**
+ * Get this course's pending edit
+ * Returns the edit awaiting admin review for this course, if there is one.
+ *
+ * While an edit is pending the course stays published and keeps serving its
+ * last-approved content to learners. The proposed content lives on the draft
+ * course referenced by `draft_course_uuid`, which only the course owner can see.
+ *
+ * **Authorization:** Only the course owner.
+ *
+ */
+export const getPendingEdit = <ThrowOnError extends boolean = false>(
+  options: Options<GetPendingEditData, ThrowOnError>
+) => {
+  return (options.client ?? _heyApiClient).get<
+    GetPendingEditResponses,
+    GetPendingEditErrors,
+    ThrowOnError
+  >({
+    responseTransformer: getPendingEditResponseTransformer,
+    security: [
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+    ],
+    url: '/api/v1/courses/{uuid}/pending-edit',
     ...options,
   });
 };
@@ -17835,6 +18095,35 @@ export const getDashboardActivity = <ThrowOnError extends boolean = false>(
 };
 
 /**
+ * Show what a pending edit would change
+ * The difference between the live course and the edit awaiting review: which
+ * course fields change and how many lessons the edit adds, removes or modifies.
+ *
+ */
+export const getCourseEditDiff = <ThrowOnError extends boolean = false>(
+  options: Options<GetCourseEditDiffData, ThrowOnError>
+) => {
+  return (options.client ?? _heyApiClient).get<
+    GetCourseEditDiffResponses,
+    GetCourseEditDiffErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+    ],
+    url: '/api/v1/admin/courses/{uuid}/pending-edit/diff',
+    ...options,
+  });
+};
+
+/**
  * Get course moderation history
  */
 export const getCourseModerationHistory = <ThrowOnError extends boolean = false>(
@@ -17888,7 +18177,13 @@ export const getCourseApprovalStatus = <ThrowOnError extends boolean = false>(
 };
 
 /**
- * List courses pending approval
+ * List courses pending first approval
+ * Courses that have never been approved and are waiting on an initial decision.
+ *
+ * This does **not** include already-published courses with a pending edit: those
+ * keep `admin_approved = true` while their edit is reviewed, so they never match
+ * this query. Use `GET /api/v1/admin/courses/pending-edits` for those.
+ *
  */
 export const listPendingCourses = <ThrowOnError extends boolean = false>(
   options: Options<ListPendingCoursesData, ThrowOnError>
@@ -17910,6 +18205,40 @@ export const listPendingCourses = <ThrowOnError extends boolean = false>(
       },
     ],
     url: '/api/v1/admin/courses/pending',
+    ...options,
+  });
+};
+
+/**
+ * List edits to published courses awaiting review
+ * Edits submitted against already-published courses, newest first.
+ *
+ * Each of these courses is still live and serving its last-approved content —
+ * the proposed change is held on a draft and is invisible to learners until
+ * approved. Approving promotes the draft onto the live course; rejecting
+ * discards it and leaves the live course exactly as it was.
+ *
+ */
+export const listPendingCourseEdits = <ThrowOnError extends boolean = false>(
+  options: Options<ListPendingCourseEditsData, ThrowOnError>
+) => {
+  return (options.client ?? _heyApiClient).get<
+    ListPendingCourseEditsResponses,
+    ListPendingCourseEditsErrors,
+    ThrowOnError
+  >({
+    responseTransformer: listPendingCourseEditsResponseTransformer,
+    security: [
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+      {
+        scheme: 'bearer',
+        type: 'http',
+      },
+    ],
+    url: '/api/v1/admin/courses/pending-edits',
     ...options,
   });
 };

--- a/services/client/transformers.gen.ts
+++ b/services/client/transformers.gen.ts
@@ -233,6 +233,7 @@ import type {
   CreateClassDefinitionForProgramMultipartResponse,
   ListJobsResponse,
   CreateJobResponse,
+  UploadJobThumbnailResponse,
   CancelJobResponse,
   AssignInstructorResponse,
   ListJobApplicationsResponse,
@@ -348,6 +349,9 @@ import type {
   GetEnrollmentsForInstanceResponse,
   GetEnrollmentCountResponse,
   ListCurrenciesResponse,
+  GetCourseVersionsResponse,
+  WithdrawPendingEditResponse,
+  GetPendingEditResponse,
   GetPrimaryRubricResponse,
   GetRubricsByContextResponse,
   GetEnrollmentGradeBookResponse,
@@ -415,6 +419,7 @@ import type {
   GetDashboardActivityResponse,
   GetCourseModerationHistoryResponse,
   ListPendingCoursesResponse,
+  ListPendingCourseEditsResponse,
   RemoveItemResponse,
   RemoveAdminDomainResponse,
 } from './types.gen';
@@ -4322,6 +4327,13 @@ export const createJobResponseTransformer = async (data: any): Promise<CreateJob
   return data;
 };
 
+export const uploadJobThumbnailResponseTransformer = async (
+  data: any
+): Promise<UploadJobThumbnailResponse> => {
+  data = apiResponseClassMarketplaceJobSchemaResponseTransformer(data);
+  return data;
+};
+
 export const cancelJobResponseTransformer = async (data: any): Promise<CancelJobResponse> => {
   data = apiResponseClassMarketplaceJobSchemaResponseTransformer(data);
   return data;
@@ -6014,6 +6026,70 @@ export const listCurrenciesResponseTransformer = async (
   return data;
 };
 
+const courseVersionSnapshotSchemaResponseTransformer = (data: any) => {
+  if (data.created_date) {
+    data.created_date = new Date(data.created_date);
+  }
+  return data;
+};
+
+const pagedDtoCourseVersionSnapshotSchemaResponseTransformer = (data: any) => {
+  if (data.content) {
+    data.content = data.content.map((item: any) => {
+      return courseVersionSnapshotSchemaResponseTransformer(item);
+    });
+  }
+  if (data.metadata) {
+    data.metadata = pageMetadataSchemaResponseTransformer(data.metadata);
+  }
+  return data;
+};
+
+const apiResponsePagedDtoCourseVersionSnapshotSchemaResponseTransformer = (data: any) => {
+  if (data.data) {
+    data.data = pagedDtoCourseVersionSnapshotSchemaResponseTransformer(data.data);
+  }
+  return data;
+};
+
+export const getCourseVersionsResponseTransformer = async (
+  data: any
+): Promise<GetCourseVersionsResponse> => {
+  data = apiResponsePagedDtoCourseVersionSnapshotSchemaResponseTransformer(data);
+  return data;
+};
+
+const coursePendingEditSchemaResponseTransformer = (data: any) => {
+  if (data.submitted_at) {
+    data.submitted_at = new Date(data.submitted_at);
+  }
+  if (data.reviewed_at) {
+    data.reviewed_at = new Date(data.reviewed_at);
+  }
+  return data;
+};
+
+const apiResponseCoursePendingEditSchemaResponseTransformer = (data: any) => {
+  if (data.data) {
+    data.data = coursePendingEditSchemaResponseTransformer(data.data);
+  }
+  return data;
+};
+
+export const withdrawPendingEditResponseTransformer = async (
+  data: any
+): Promise<WithdrawPendingEditResponse> => {
+  data = apiResponseCoursePendingEditSchemaResponseTransformer(data);
+  return data;
+};
+
+export const getPendingEditResponseTransformer = async (
+  data: any
+): Promise<GetPendingEditResponse> => {
+  data = apiResponseCoursePendingEditSchemaResponseTransformer(data);
+  return data;
+};
+
 export const getPrimaryRubricResponseTransformer = async (
   data: any
 ): Promise<GetPrimaryRubricResponse> => {
@@ -7117,6 +7193,32 @@ export const listPendingCoursesResponseTransformer = async (
   data: any
 ): Promise<ListPendingCoursesResponse> => {
   data = apiResponsePagedDtoCourseSchemaResponseTransformer(data);
+  return data;
+};
+
+const pagedDtoCoursePendingEditSchemaResponseTransformer = (data: any) => {
+  if (data.content) {
+    data.content = data.content.map((item: any) => {
+      return coursePendingEditSchemaResponseTransformer(item);
+    });
+  }
+  if (data.metadata) {
+    data.metadata = pageMetadataSchemaResponseTransformer(data.metadata);
+  }
+  return data;
+};
+
+const apiResponsePagedDtoCoursePendingEditSchemaResponseTransformer = (data: any) => {
+  if (data.data) {
+    data.data = pagedDtoCoursePendingEditSchemaResponseTransformer(data.data);
+  }
+  return data;
+};
+
+export const listPendingCourseEditsResponseTransformer = async (
+  data: any
+): Promise<ListPendingCourseEditsResponse> => {
+  data = apiResponsePagedDtoCoursePendingEditSchemaResponseTransformer(data);
   return data;
 };
 

--- a/services/client/types.gen.ts
+++ b/services/client/types.gen.ts
@@ -1629,11 +1629,6 @@ export type InstructorProfessionalMembership = {
    */
   readonly formatted_duration?: string | null;
   /**
-   * **[READ-ONLY]** Duration of membership calculated from start and end dates, in months.
-   */
-  readonly membership_duration_months?: number | null;
-  membership_status?: MembershipStatusEnum;
-  /**
    * **[READ-ONLY]** Formatted membership period showing start and end dates.
    */
   readonly membership_period?: string | null;
@@ -1654,6 +1649,11 @@ export type InstructorProfessionalMembership = {
    * **[READ-ONLY]** Indicates if this membership was started within the last 3 years.
    */
   readonly is_recent_membership?: boolean;
+  /**
+   * **[READ-ONLY]** Duration of membership calculated from start and end dates, in months.
+   */
+  readonly membership_duration_months?: number | null;
+  membership_status?: MembershipStatusEnum;
   /**
    * **[READ-ONLY]** Indicates if the membership is currently valid and active.
    */
@@ -3943,6 +3943,10 @@ export type ClassMarketplaceJob = {
   readonly registration_period_end_date?: Date;
   readonly class_reminder_minutes?: number;
   readonly class_color?: string;
+  /**
+   * Public URL to the class advert thumbnail image, if uploaded.
+   */
+  readonly thumbnail_url?: string;
   location_type?: LocationTypeEnum;
   readonly location_name?: string;
   readonly location_latitude?: number;
@@ -4874,6 +4878,44 @@ export type GuardianStudentLinkRequest = {
    * Optional note shown in audits or invitation emails
    */
   notes?: string;
+};
+
+export type ApiResponseSweepReport = {
+  success?: boolean;
+  data?: SweepReport;
+  message?: string;
+  error?: unknown;
+};
+
+export type SweepReport = {
+  diskFiles?: number;
+  referencedKeys?: number;
+  orphanKeys?: Array<string>;
+  orphansDeleted?: number;
+};
+
+export type ApiResponseReconcileReport = {
+  success?: boolean;
+  data?: ReconcileReport;
+  message?: string;
+  error?: unknown;
+};
+
+export type DeadReference = {
+  table?: string;
+  column?: string;
+  rowUuid?: string;
+  value?: string;
+  nullable?: boolean;
+};
+
+export type ReconcileReport = {
+  registryRowsChecked?: number;
+  registryMarkedMissing?: number;
+  registryMetadataFilled?: number;
+  deadReferences?: Array<DeadReference>;
+  deadReferencesPruned?: number;
+  orphanRowsDeleted?: number;
 };
 
 /**
@@ -6252,6 +6294,22 @@ export type AdminCreateUserRequestDto = {
   phone_number?: string;
 };
 
+/**
+ * Payload for a moderation decision on a course or training program.
+ *
+ * When the content has a pending edit awaiting review, `approved` promotes that
+ * edit onto the live content and `rejected` discards it, leaving the live content
+ * untouched. Otherwise the decision applies to the content's own approval state.
+ *
+ */
+export type ContentModerationDecisionRequest = {
+  action: ActionEnum;
+  /**
+   * Reason for the decision. Shown to the course creator and retained in the moderation history.
+   */
+  reason?: string | null;
+};
+
 export type OrganisationUserCreateRequestDto = {
   /**
    * First name of the user
@@ -6615,8 +6673,8 @@ export type PageableObject = {
 };
 
 export type SortObject = {
-  sorted?: boolean;
   unsorted?: boolean;
+  sorted?: boolean;
   empty?: boolean;
 };
 
@@ -7926,11 +7984,112 @@ export type PagedDtoCourse = {
   links?: PageLinks;
 };
 
+export type ApiResponsePagedDtoCourseVersionSnapshot = {
+  success?: boolean;
+  data?: PagedDtoCourseVersionSnapshot;
+  message?: string;
+  error?: unknown;
+};
+
+/**
+ * An approved version of a course's content. One is written each time an edit is
+ * promoted onto the live course, giving a durable record of what the course
+ * looked like at each approved version.
+ *
+ */
+export type CourseVersionSnapshot = {
+  /**
+   * **[READ-ONLY]** Unique identifier for the snapshot.
+   */
+  readonly uuid?: string;
+  /**
+   * **[READ-ONLY]** Full course tree at this version: course fields, category uuids, lessons and their content.
+   */
+  snapshot?: JsonNode;
+  /**
+   * **[READ-ONLY]** The course this version belongs to.
+   */
+  readonly course_uuid?: string;
+  /**
+   * **[READ-ONLY]** Monotonic version number, starting at 1.
+   */
+  readonly version_number?: number;
+  /**
+   * **[READ-ONLY]** The edit whose promotion produced this version, if any.
+   */
+  readonly pending_edit_uuid?: string;
+  /**
+   * **[READ-ONLY]** When this version became live.
+   */
+  readonly created_date?: Date;
+  /**
+   * **[READ-ONLY]** Who promoted this version.
+   */
+  readonly created_by?: string;
+};
+
+export type PagedDtoCourseVersionSnapshot = {
+  content?: Array<CourseVersionSnapshot>;
+  metadata?: PageMetadata;
+  links?: PageLinks;
+};
+
 export type ApiResponseListContentStatus = {
   success?: boolean;
   data?: Array<SchemaEnum4>;
   message?: string;
   error?: unknown;
+};
+
+export type ApiResponseCoursePendingEdit = {
+  success?: boolean;
+  data?: CoursePendingEdit;
+  message?: string;
+  error?: unknown;
+};
+
+/**
+ * An edit to a published course that is awaiting admin review.
+ *
+ * The live course is unaffected while the edit is pending: it stays published,
+ * keeps accepting enrollments, and continues to serve its last-approved content.
+ * The proposed content lives on the draft course referenced by `draft_course_uuid`.
+ *
+ */
+export type CoursePendingEdit = {
+  /**
+   * **[READ-ONLY]** Unique identifier for the pending edit.
+   */
+  readonly uuid?: string;
+  status?: StatusEnum19;
+  /**
+   * **[READ-ONLY]** The live course this edit applies to.
+   */
+  readonly course_uuid?: string;
+  /**
+   * **[READ-ONLY]** Draft course holding the proposed content. Null once the edit is resolved.
+   */
+  readonly draft_course_uuid?: string;
+  /**
+   * **[READ-ONLY]** Internal user UUID of the course creator who submitted the edit.
+   */
+  readonly submitted_by_uuid?: string;
+  /**
+   * **[READ-ONLY]** When the edit was submitted for review.
+   */
+  readonly submitted_at?: Date;
+  /**
+   * **[READ-ONLY]** Internal user UUID of the admin who reviewed the edit.
+   */
+  readonly reviewed_by_uuid?: string;
+  /**
+   * **[READ-ONLY]** When the edit was reviewed.
+   */
+  readonly reviewed_at?: Date;
+  /**
+   * **[READ-ONLY]** Reason the admin gave for their decision.
+   */
+  readonly review_reason?: string;
 };
 
 export type ApiResponsePagedDtoCourseTrainingRequirement = {
@@ -9193,6 +9352,76 @@ export type ApiResponseListCurrency = {
   error?: unknown;
 };
 
+export type ApiResponseCourseEditDiff = {
+  success?: boolean;
+  data?: CourseEditDiff;
+  message?: string;
+  error?: unknown;
+};
+
+/**
+ * What a pending edit would change if approved, so an admin can review the
+ * decision without comparing two full course payloads by eye.
+ *
+ */
+export type CourseEditDiff = {
+  /**
+   * **[READ-ONLY]** The live course under review.
+   */
+  readonly course_uuid?: string;
+  /**
+   * **[READ-ONLY]** Draft course holding the proposed content.
+   */
+  readonly draft_course_uuid?: string;
+  /**
+   * **[READ-ONLY]** Course fields that differ between the live course and the draft.
+   */
+  readonly field_changes?: Array<CourseEditFieldChange>;
+  /**
+   * **[READ-ONLY]** Lessons the edit adds.
+   */
+  readonly lessons_added?: number;
+  /**
+   * **[READ-ONLY]** Lessons the edit removes.
+   */
+  readonly lessons_removed?: number;
+  /**
+   * **[READ-ONLY]** Lessons the edit changes in place.
+   */
+  readonly lessons_modified?: number;
+};
+
+/**
+ * A single course field the edit would change.
+ */
+export type CourseEditFieldChange = {
+  /**
+   * **[READ-ONLY]** Field name, in snake_case as it appears on the course payload.
+   */
+  readonly field?: string;
+  /**
+   * **[READ-ONLY]** Current value on the live course, rendered as text.
+   */
+  readonly live_value?: string;
+  /**
+   * **[READ-ONLY]** Proposed value on the draft, rendered as text.
+   */
+  readonly draft_value?: string;
+};
+
+export type ApiResponsePagedDtoCoursePendingEdit = {
+  success?: boolean;
+  data?: PagedDtoCoursePendingEdit;
+  message?: string;
+  error?: unknown;
+};
+
+export type PagedDtoCoursePendingEdit = {
+  content?: Array<CoursePendingEdit>;
+  metadata?: PageMetadata;
+  links?: PageLinks;
+};
+
 /**
  * Valid African phone number in international or local format
  */
@@ -9537,21 +9766,6 @@ export const ProficiencyLevelEnum = {
 export type ProficiencyLevelEnum = (typeof ProficiencyLevelEnum)[keyof typeof ProficiencyLevelEnum];
 
 /**
- * **[READ-ONLY]** Current status of the membership.
- */
-export const MembershipStatusEnum = {
-  ACTIVE: 'ACTIVE',
-  INACTIVE: 'INACTIVE',
-  EXPIRED: 'EXPIRED',
-  UNKNOWN: 'UNKNOWN',
-} as const;
-
-/**
- * **[READ-ONLY]** Current status of the membership.
- */
-export type MembershipStatusEnum = (typeof MembershipStatusEnum)[keyof typeof MembershipStatusEnum];
-
-/**
  * **[READ-ONLY]** Classification of organisation type based on name keywords.
  */
 export const OrganisationTypeEnum = {
@@ -9567,6 +9781,21 @@ export const OrganisationTypeEnum = {
  * **[READ-ONLY]** Classification of organisation type based on name keywords.
  */
 export type OrganisationTypeEnum = (typeof OrganisationTypeEnum)[keyof typeof OrganisationTypeEnum];
+
+/**
+ * **[READ-ONLY]** Current status of the membership.
+ */
+export const MembershipStatusEnum = {
+  ACTIVE: 'ACTIVE',
+  INACTIVE: 'INACTIVE',
+  EXPIRED: 'EXPIRED',
+  UNKNOWN: 'UNKNOWN',
+} as const;
+
+/**
+ * **[READ-ONLY]** Current status of the membership.
+ */
+export type MembershipStatusEnum = (typeof MembershipStatusEnum)[keyof typeof MembershipStatusEnum];
 
 /**
  * **[READ-ONLY]** Classification of experience level based on position title and duration.
@@ -10135,6 +10364,20 @@ export const AssignmentTypeEnum = {
 export type AssignmentTypeEnum = (typeof AssignmentTypeEnum)[keyof typeof AssignmentTypeEnum];
 
 /**
+ * The decision to apply.
+ */
+export const ActionEnum = {
+  APPROVED: 'approved',
+  REJECTED: 'rejected',
+  REVOKED: 'revoked',
+} as const;
+
+/**
+ * The decision to apply.
+ */
+export type ActionEnum = (typeof ActionEnum)[keyof typeof ActionEnum];
+
+/**
  * Domain/role to assign within the organisation
  */
 export const DomainNameEnum2 = {
@@ -10300,18 +10543,19 @@ export const EntryTypeEnum2 = {
 export type EntryTypeEnum2 = (typeof EntryTypeEnum2)[keyof typeof EntryTypeEnum2];
 
 /**
- * **[READ-ONLY]** Moderation decision taken.
+ * **[READ-ONLY]** Review state of the edit.
  */
-export const ActionEnum = {
+export const StatusEnum19 = {
+  PENDING: 'pending',
   APPROVED: 'approved',
   REJECTED: 'rejected',
-  REVOKED: 'revoked',
+  WITHDRAWN: 'withdrawn',
 } as const;
 
 /**
- * **[READ-ONLY]** Moderation decision taken.
+ * **[READ-ONLY]** Review state of the edit.
  */
-export type ActionEnum = (typeof ActionEnum)[keyof typeof ActionEnum];
+export type StatusEnum19 = (typeof StatusEnum19)[keyof typeof StatusEnum19];
 
 /**
  * **[READ-ONLY]** Type of the moderated content.
@@ -11093,6 +11337,20 @@ export const AssignmentTypeEnumWritable = {
  */
 export type AssignmentTypeEnumWritable =
   (typeof AssignmentTypeEnumWritable)[keyof typeof AssignmentTypeEnumWritable];
+
+/**
+ * The decision to apply.
+ */
+export const ActionEnumWritable = {
+  APPROVED: 'approved',
+  REJECTED: 'rejected',
+  REVOKED: 'revoked',
+} as const;
+
+/**
+ * The decision to apply.
+ */
+export type ActionEnumWritable = (typeof ActionEnumWritable)[keyof typeof ActionEnumWritable];
 
 /**
  * Domain/role to assign within the organisation
@@ -18359,6 +18617,74 @@ export type CreateLinkResponses = {
 
 export type CreateLinkResponse = CreateLinkResponses[keyof CreateLinkResponses];
 
+export type SweepData = {
+  body?: never;
+  path?: never;
+  query?: {
+    /**
+     * Delete the orphaned files instead of only reporting them
+     */
+    deleteOrphans?: boolean;
+  };
+  url: '/api/v1/files/admin/sweep';
+};
+
+export type SweepErrors = {
+  /**
+   * Not Found
+   */
+  404: ResponseDtoVoid;
+  /**
+   * Internal Server Error
+   */
+  500: ResponseDtoVoid;
+};
+
+export type SweepError = SweepErrors[keyof SweepErrors];
+
+export type SweepResponses = {
+  /**
+   * OK
+   */
+  200: ApiResponseSweepReport;
+};
+
+export type SweepResponse = SweepResponses[keyof SweepResponses];
+
+export type ReconcileData = {
+  body?: never;
+  path?: never;
+  query?: {
+    /**
+     * Clear domain references whose files no longer exist on disk
+     */
+    prune?: boolean;
+  };
+  url: '/api/v1/files/admin/reconcile';
+};
+
+export type ReconcileErrors = {
+  /**
+   * Not Found
+   */
+  404: ResponseDtoVoid;
+  /**
+   * Internal Server Error
+   */
+  500: ResponseDtoVoid;
+};
+
+export type ReconcileError = ReconcileErrors[keyof ReconcileErrors];
+
+export type ReconcileResponses = {
+  /**
+   * OK
+   */
+  200: ApiResponseReconcileReport;
+};
+
+export type ReconcileResponse = ReconcileResponses[keyof ReconcileResponses];
+
 export type EnrollStudentData = {
   body: EnrollmentRequest;
   path?: never;
@@ -21285,6 +21611,40 @@ export type CreateJobResponses = {
 
 export type CreateJobResponse = CreateJobResponses[keyof CreateJobResponses];
 
+export type UploadJobThumbnailData = {
+  body?: {
+    thumbnail: Blob | File;
+  };
+  path: {
+    uuid: string;
+  };
+  query?: never;
+  url: '/api/v1/classes/jobs/{uuid}/thumbnail';
+};
+
+export type UploadJobThumbnailErrors = {
+  /**
+   * Not Found
+   */
+  404: ResponseDtoVoid;
+  /**
+   * Internal Server Error
+   */
+  500: ResponseDtoVoid;
+};
+
+export type UploadJobThumbnailError = UploadJobThumbnailErrors[keyof UploadJobThumbnailErrors];
+
+export type UploadJobThumbnailResponses = {
+  /**
+   * OK
+   */
+  200: ApiResponseClassMarketplaceJob;
+};
+
+export type UploadJobThumbnailResponse =
+  UploadJobThumbnailResponses[keyof UploadJobThumbnailResponses];
+
 export type CancelJobData = {
   body?: never;
   path: {
@@ -22325,14 +22685,14 @@ export type CreateAdminUserResponses = {
 export type CreateAdminUserResponse = CreateAdminUserResponses[keyof CreateAdminUserResponses];
 
 export type ModerateProgramData = {
-  body?: never;
+  body: ContentModerationDecisionRequest;
   path: {
+    /**
+     * UUID of the training program
+     */
     uuid: string;
   };
-  query: {
-    action: string;
-    reason?: string;
-  };
+  query?: never;
   url: '/api/v1/admin/programs/{uuid}/moderate';
 };
 
@@ -22690,22 +23050,26 @@ export type ActivateResponses = {
 export type ActivateResponse = ActivateResponses[keyof ActivateResponses];
 
 export type ModerateCourseData = {
-  body?: never;
+  body: ContentModerationDecisionRequest;
   path: {
+    /**
+     * UUID of the course
+     */
     uuid: string;
   };
-  query: {
-    action: string;
-    reason?: string;
-  };
+  query?: never;
   url: '/api/v1/admin/courses/{uuid}/moderate';
 };
 
 export type ModerateCourseErrors = {
   /**
-   * Not Found
+   * Unsupported action
    */
-  404: ResponseDtoVoid;
+  400: ApiResponseCourse;
+  /**
+   * Course not found
+   */
+  404: unknown;
   /**
    * Internal Server Error
    */
@@ -22716,7 +23080,7 @@ export type ModerateCourseError = ModerateCourseErrors[keyof ModerateCourseError
 
 export type ModerateCourseResponses = {
   /**
-   * OK
+   * Decision applied successfully
    */
   200: ApiResponseCourse;
 };
@@ -26109,6 +26473,40 @@ export type GetMyStudentsResponses = {
 
 export type GetMyStudentsResponse = GetMyStudentsResponses[keyof GetMyStudentsResponses];
 
+export type GetFileData = {
+  body?: never;
+  path: {
+    /**
+     * Canonical storage key, e.g. course_thumbnails/uuid.jpg
+     */
+    key: string;
+  };
+  query?: never;
+  url: '/api/v1/files/{key}';
+};
+
+export type GetFileErrors = {
+  /**
+   * File not found
+   */
+  404: ResponseDtoVoid;
+  /**
+   * Internal Server Error
+   */
+  500: ResponseDtoVoid;
+};
+
+export type GetFileError = GetFileErrors[keyof GetFileErrors];
+
+export type GetFileResponses = {
+  /**
+   * File retrieved successfully
+   */
+  200: Blob | File;
+};
+
+export type GetFileResponse = GetFileResponses[keyof GetFileResponses];
+
 export type CancelEnrollmentData = {
   body?: never;
   path: {
@@ -26571,6 +26969,47 @@ export type GetDefaultCurrencyResponses = {
 export type GetDefaultCurrencyResponse =
   GetDefaultCurrencyResponses[keyof GetDefaultCurrencyResponses];
 
+export type GetCourseVersionsData = {
+  body?: never;
+  path: {
+    /**
+     * UUID of the course
+     */
+    uuid: string;
+  };
+  query: {
+    pageable: Pageable;
+  };
+  url: '/api/v1/courses/{uuid}/versions';
+};
+
+export type GetCourseVersionsErrors = {
+  /**
+   * Not the course owner
+   */
+  403: ApiResponsePagedDtoCourseVersionSnapshot;
+  /**
+   * Not Found
+   */
+  404: ResponseDtoVoid;
+  /**
+   * Internal Server Error
+   */
+  500: ResponseDtoVoid;
+};
+
+export type GetCourseVersionsError = GetCourseVersionsErrors[keyof GetCourseVersionsErrors];
+
+export type GetCourseVersionsResponses = {
+  /**
+   * Version history retrieved
+   */
+  200: ApiResponsePagedDtoCourseVersionSnapshot;
+};
+
+export type GetCourseVersionsResponse =
+  GetCourseVersionsResponses[keyof GetCourseVersionsResponses];
+
 export type GetStatusTransitionsData = {
   body?: never;
   path: {
@@ -26603,6 +27042,87 @@ export type GetStatusTransitionsResponses = {
 
 export type GetStatusTransitionsResponse =
   GetStatusTransitionsResponses[keyof GetStatusTransitionsResponses];
+
+export type WithdrawPendingEditData = {
+  body?: never;
+  path: {
+    /**
+     * UUID of the course
+     */
+    uuid: string;
+  };
+  query?: never;
+  url: '/api/v1/courses/{uuid}/pending-edit';
+};
+
+export type WithdrawPendingEditErrors = {
+  /**
+   * Not the course owner
+   */
+  403: ApiResponseCoursePendingEdit;
+  /**
+   * No edit awaiting review
+   */
+  404: unknown;
+  /**
+   * Internal Server Error
+   */
+  500: ResponseDtoVoid;
+};
+
+export type WithdrawPendingEditError = WithdrawPendingEditErrors[keyof WithdrawPendingEditErrors];
+
+export type WithdrawPendingEditResponses = {
+  /**
+   * Pending edit withdrawn
+   */
+  200: ApiResponseCoursePendingEdit;
+};
+
+export type WithdrawPendingEditResponse =
+  WithdrawPendingEditResponses[keyof WithdrawPendingEditResponses];
+
+export type GetPendingEditData = {
+  body?: never;
+  path: {
+    /**
+     * UUID of the course
+     */
+    uuid: string;
+  };
+  query?: never;
+  url: '/api/v1/courses/{uuid}/pending-edit';
+};
+
+export type GetPendingEditErrors = {
+  /**
+   * Not the course owner
+   */
+  403: ApiResponseCoursePendingEdit;
+  /**
+   * Not Found
+   */
+  404: ResponseDtoVoid;
+  /**
+   * Internal Server Error
+   */
+  500: ResponseDtoVoid;
+};
+
+export type GetPendingEditError = GetPendingEditErrors[keyof GetPendingEditErrors];
+
+export type GetPendingEditResponses = {
+  /**
+   * Pending edit retrieved
+   */
+  200: ApiResponseCoursePendingEdit;
+  /**
+   * No edit awaiting review
+   */
+  204: ApiResponseCoursePendingEdit;
+};
+
+export type GetPendingEditResponse = GetPendingEditResponses[keyof GetPendingEditResponses];
 
 export type CheckRubricAssociationData = {
   body?: never;
@@ -29661,6 +30181,41 @@ export type GetDashboardActivityResponses = {
 export type GetDashboardActivityResponse =
   GetDashboardActivityResponses[keyof GetDashboardActivityResponses];
 
+export type GetCourseEditDiffData = {
+  body?: never;
+  path: {
+    /**
+     * UUID of the live course
+     */
+    uuid: string;
+  };
+  query?: never;
+  url: '/api/v1/admin/courses/{uuid}/pending-edit/diff';
+};
+
+export type GetCourseEditDiffErrors = {
+  /**
+   * No edit awaiting review for this course
+   */
+  404: unknown;
+  /**
+   * Internal Server Error
+   */
+  500: ResponseDtoVoid;
+};
+
+export type GetCourseEditDiffError = GetCourseEditDiffErrors[keyof GetCourseEditDiffErrors];
+
+export type GetCourseEditDiffResponses = {
+  /**
+   * Diff retrieved
+   */
+  200: ApiResponseCourseEditDiff;
+};
+
+export type GetCourseEditDiffResponse =
+  GetCourseEditDiffResponses[keyof GetCourseEditDiffResponses];
+
 export type GetCourseModerationHistoryData = {
   body?: never;
   path: {
@@ -29760,6 +30315,39 @@ export type ListPendingCoursesResponses = {
 
 export type ListPendingCoursesResponse =
   ListPendingCoursesResponses[keyof ListPendingCoursesResponses];
+
+export type ListPendingCourseEditsData = {
+  body?: never;
+  path?: never;
+  query: {
+    pageable: Pageable;
+  };
+  url: '/api/v1/admin/courses/pending-edits';
+};
+
+export type ListPendingCourseEditsErrors = {
+  /**
+   * Not Found
+   */
+  404: ResponseDtoVoid;
+  /**
+   * Internal Server Error
+   */
+  500: ResponseDtoVoid;
+};
+
+export type ListPendingCourseEditsError =
+  ListPendingCourseEditsErrors[keyof ListPendingCourseEditsErrors];
+
+export type ListPendingCourseEditsResponses = {
+  /**
+   * Pending edits retrieved successfully
+   */
+  200: ApiResponsePagedDtoCoursePendingEdit;
+};
+
+export type ListPendingCourseEditsResponse =
+  ListPendingCourseEditsResponses[keyof ListPendingCourseEditsResponses];
 
 export type ClearInstructorAvailabilityData = {
   body?: never;

--- a/services/client/zod.gen.ts
+++ b/services/client/zod.gen.ts
@@ -2110,13 +2110,6 @@ export const zApiResponseInstructorSkill = z.object({
 });
 
 /**
- * **[READ-ONLY]** Current status of the membership.
- */
-export const zMembershipStatusEnum = z
-  .enum(['ACTIVE', 'INACTIVE', 'EXPIRED', 'UNKNOWN'])
-  .describe('**[READ-ONLY]** Current status of the membership.');
-
-/**
  * **[READ-ONLY]** Classification of organisation type based on name keywords.
  */
 export const zOrganisationTypeEnum = z
@@ -2129,6 +2122,13 @@ export const zOrganisationTypeEnum = z
     'OTHER',
   ])
   .describe('**[READ-ONLY]** Classification of organisation type based on name keywords.');
+
+/**
+ * **[READ-ONLY]** Current status of the membership.
+ */
+export const zMembershipStatusEnum = z
+  .enum(['ACTIVE', 'INACTIVE', 'EXPIRED', 'UNKNOWN'])
+  .describe('**[READ-ONLY]** Current status of the membership.');
 
 /**
  * Professional membership record for instructors including associations, industry bodies, and certification organizations
@@ -2199,11 +2199,6 @@ export const zInstructorProfessionalMembership = z
       .readonly()
       .optional(),
     formatted_duration: z.union([z.string().readonly(), z.null()]).readonly().optional(),
-    membership_duration_months: z
-      .union([z.number().int().readonly(), z.null()])
-      .readonly()
-      .optional(),
-    membership_status: zMembershipStatusEnum.optional(),
     membership_period: z.union([z.string().readonly(), z.null()]).readonly().optional(),
     is_long_standing_member: z
       .boolean()
@@ -2222,6 +2217,11 @@ export const zInstructorProfessionalMembership = z
       .describe('**[READ-ONLY]** Indicates if this membership was started within the last 3 years.')
       .readonly()
       .optional(),
+    membership_duration_months: z
+      .union([z.number().int().readonly(), z.null()])
+      .readonly()
+      .optional(),
+    membership_status: zMembershipStatusEnum.optional(),
     is_valid: z
       .boolean()
       .describe('**[READ-ONLY]** Indicates if the membership is currently valid and active.')
@@ -5000,6 +5000,11 @@ export const zClassMarketplaceJob = z
     registration_period_end_date: z.string().date().readonly().optional(),
     class_reminder_minutes: z.number().int().readonly().optional(),
     class_color: z.string().readonly().optional(),
+    thumbnail_url: z
+      .string()
+      .describe('Public URL to the class advert thumbnail image, if uploaded.')
+      .readonly()
+      .optional(),
     location_type: zLocationTypeEnum.optional(),
     location_name: z.string().readonly().optional(),
     location_latitude: z.number().readonly().optional(),
@@ -6094,6 +6099,44 @@ export const zGuardianStudentLinkRequest = z
     notes: z.string().describe('Optional note shown in audits or invitation emails').optional(),
   })
   .describe('Request payload to link a guardian/parent to a learner profile.');
+
+export const zSweepReport = z.object({
+  diskFiles: z.number().int().optional(),
+  referencedKeys: z.number().int().optional(),
+  orphanKeys: z.array(z.string()).optional(),
+  orphansDeleted: z.number().int().optional(),
+});
+
+export const zApiResponseSweepReport = z.object({
+  success: z.boolean().optional(),
+  data: zSweepReport.optional(),
+  message: z.string().optional(),
+  error: z.unknown().optional(),
+});
+
+export const zDeadReference = z.object({
+  table: z.string().optional(),
+  column: z.string().optional(),
+  rowUuid: z.string().uuid().optional(),
+  value: z.string().optional(),
+  nullable: z.boolean().optional(),
+});
+
+export const zReconcileReport = z.object({
+  registryRowsChecked: z.number().int().optional(),
+  registryMarkedMissing: z.number().int().optional(),
+  registryMetadataFilled: z.number().int().optional(),
+  deadReferences: z.array(zDeadReference).optional(),
+  deadReferencesPruned: z.number().int().optional(),
+  orphanRowsDeleted: z.number().int().optional(),
+});
+
+export const zApiResponseReconcileReport = z.object({
+  success: z.boolean().optional(),
+  data: zReconcileReport.optional(),
+  message: z.string().optional(),
+  error: z.unknown().optional(),
+});
 
 /**
  * Request to enroll a student in a scheduled class instance
@@ -7517,6 +7560,30 @@ export const zAdminCreateUserRequestDto = z.object({
 });
 
 /**
+ * The decision to apply.
+ */
+export const zActionEnum = z
+  .enum(['approved', 'rejected', 'revoked'])
+  .describe('The decision to apply.');
+
+/**
+ * Payload for a moderation decision on a course or training program.
+ *
+ * When the content has a pending edit awaiting review, `approved` promotes that
+ * edit onto the live content and `rejected` discards it, leaving the live content
+ * untouched. Otherwise the decision applies to the content's own approval state.
+ *
+ */
+export const zContentModerationDecisionRequest = z
+  .object({
+    action: zActionEnum,
+    reason: z.union([z.string().min(0).max(2000), z.null()]).optional(),
+  })
+  .describe(
+    "Payload for a moderation decision on a course or training program.\n\nWhen the content has a pending edit awaiting review, `approved` promotes that\nedit onto the live content and `rejected` discards it, leaving the live content\nuntouched. Otherwise the decision applies to the content's own approval state.\n"
+  );
+
+/**
  * Domain/role to assign within the organisation
  */
 export const zDomainNameEnum2 = z
@@ -7903,8 +7970,8 @@ export const zApiResponsePagedDtoBookingResponse = z.object({
 });
 
 export const zSortObject = z.object({
-  sorted: z.boolean().optional(),
   unsorted: z.boolean().optional(),
+  sorted: z.boolean().optional(),
   empty: z.boolean().optional(),
 });
 
@@ -9271,9 +9338,150 @@ export const zApiResponsePagedDtoCourse = z.object({
   error: z.unknown().optional(),
 });
 
+/**
+ * An approved version of a course's content. One is written each time an edit is
+ * promoted onto the live course, giving a durable record of what the course
+ * looked like at each approved version.
+ *
+ */
+export const zCourseVersionSnapshot = z
+  .object({
+    uuid: z
+      .string()
+      .uuid()
+      .describe('**[READ-ONLY]** Unique identifier for the snapshot.')
+      .readonly()
+      .optional(),
+    snapshot: zJsonNode.optional(),
+    course_uuid: z
+      .string()
+      .uuid()
+      .describe('**[READ-ONLY]** The course this version belongs to.')
+      .readonly()
+      .optional(),
+    version_number: z
+      .number()
+      .int()
+      .describe('**[READ-ONLY]** Monotonic version number, starting at 1.')
+      .readonly()
+      .optional(),
+    pending_edit_uuid: z
+      .string()
+      .uuid()
+      .describe('**[READ-ONLY]** The edit whose promotion produced this version, if any.')
+      .readonly()
+      .optional(),
+    created_date: z
+      .string()
+      .datetime()
+      .describe('**[READ-ONLY]** When this version became live.')
+      .readonly()
+      .optional(),
+    created_by: z
+      .string()
+      .describe('**[READ-ONLY]** Who promoted this version.')
+      .readonly()
+      .optional(),
+  })
+  .describe(
+    "An approved version of a course's content. One is written each time an edit is\npromoted onto the live course, giving a durable record of what the course\nlooked like at each approved version.\n"
+  );
+
+export const zPagedDtoCourseVersionSnapshot = z.object({
+  content: z.array(zCourseVersionSnapshot).optional(),
+  metadata: zPageMetadata.optional(),
+  links: zPageLinks.optional(),
+});
+
+export const zApiResponsePagedDtoCourseVersionSnapshot = z.object({
+  success: z.boolean().optional(),
+  data: zPagedDtoCourseVersionSnapshot.optional(),
+  message: z.string().optional(),
+  error: z.unknown().optional(),
+});
+
 export const zApiResponseListContentStatus = z.object({
   success: z.boolean().optional(),
   data: z.array(zSchemaEnum4).optional(),
+  message: z.string().optional(),
+  error: z.unknown().optional(),
+});
+
+/**
+ * **[READ-ONLY]** Review state of the edit.
+ */
+export const zStatusEnum19 = z
+  .enum(['pending', 'approved', 'rejected', 'withdrawn'])
+  .describe('**[READ-ONLY]** Review state of the edit.');
+
+/**
+ * An edit to a published course that is awaiting admin review.
+ *
+ * The live course is unaffected while the edit is pending: it stays published,
+ * keeps accepting enrollments, and continues to serve its last-approved content.
+ * The proposed content lives on the draft course referenced by `draft_course_uuid`.
+ *
+ */
+export const zCoursePendingEdit = z
+  .object({
+    uuid: z
+      .string()
+      .uuid()
+      .describe('**[READ-ONLY]** Unique identifier for the pending edit.')
+      .readonly()
+      .optional(),
+    status: zStatusEnum19.optional(),
+    course_uuid: z
+      .string()
+      .uuid()
+      .describe('**[READ-ONLY]** The live course this edit applies to.')
+      .readonly()
+      .optional(),
+    draft_course_uuid: z
+      .string()
+      .uuid()
+      .describe(
+        '**[READ-ONLY]** Draft course holding the proposed content. Null once the edit is resolved.'
+      )
+      .readonly()
+      .optional(),
+    submitted_by_uuid: z
+      .string()
+      .uuid()
+      .describe('**[READ-ONLY]** Internal user UUID of the course creator who submitted the edit.')
+      .readonly()
+      .optional(),
+    submitted_at: z
+      .string()
+      .datetime()
+      .describe('**[READ-ONLY]** When the edit was submitted for review.')
+      .readonly()
+      .optional(),
+    reviewed_by_uuid: z
+      .string()
+      .uuid()
+      .describe('**[READ-ONLY]** Internal user UUID of the admin who reviewed the edit.')
+      .readonly()
+      .optional(),
+    reviewed_at: z
+      .string()
+      .datetime()
+      .describe('**[READ-ONLY]** When the edit was reviewed.')
+      .readonly()
+      .optional(),
+    review_reason: z
+      .string()
+      .describe('**[READ-ONLY]** Reason the admin gave for their decision.')
+      .readonly()
+      .optional(),
+  })
+  .describe(
+    'An edit to a published course that is awaiting admin review.\n\nThe live course is unaffected while the edit is pending: it stays published,\nkeeps accepting enrollments, and continues to serve its last-approved content.\nThe proposed content lives on the draft course referenced by `draft_course_uuid`.\n'
+  );
+
+export const zApiResponseCoursePendingEdit = z.object({
+  success: z.boolean().optional(),
+  data: zCoursePendingEdit.optional(),
   message: z.string().optional(),
   error: z.unknown().optional(),
 });
@@ -10253,13 +10461,6 @@ export const zApiResponsePagedDtoAdminUserActivityEvent = z.object({
 });
 
 /**
- * **[READ-ONLY]** Moderation decision taken.
- */
-export const zActionEnum = z
-  .enum(['approved', 'rejected', 'revoked'])
-  .describe('**[READ-ONLY]** Moderation decision taken.');
-
-/**
  * **[READ-ONLY]** Type of the moderated content.
  */
 export const zContentTypeEnum = z
@@ -10579,6 +10780,96 @@ export const zApiResponsePagedDtoAdminActivityEvent = z.object({
 export const zApiResponseListCurrency = z.object({
   success: z.boolean().optional(),
   data: z.array(zCurrency).optional(),
+  message: z.string().optional(),
+  error: z.unknown().optional(),
+});
+
+/**
+ * A single course field the edit would change.
+ */
+export const zCourseEditFieldChange = z
+  .object({
+    field: z
+      .string()
+      .describe('**[READ-ONLY]** Field name, in snake_case as it appears on the course payload.')
+      .readonly()
+      .optional(),
+    live_value: z
+      .string()
+      .describe('**[READ-ONLY]** Current value on the live course, rendered as text.')
+      .readonly()
+      .optional(),
+    draft_value: z
+      .string()
+      .describe('**[READ-ONLY]** Proposed value on the draft, rendered as text.')
+      .readonly()
+      .optional(),
+  })
+  .describe('A single course field the edit would change.');
+
+/**
+ * What a pending edit would change if approved, so an admin can review the
+ * decision without comparing two full course payloads by eye.
+ *
+ */
+export const zCourseEditDiff = z
+  .object({
+    course_uuid: z
+      .string()
+      .uuid()
+      .describe('**[READ-ONLY]** The live course under review.')
+      .readonly()
+      .optional(),
+    draft_course_uuid: z
+      .string()
+      .uuid()
+      .describe('**[READ-ONLY]** Draft course holding the proposed content.')
+      .readonly()
+      .optional(),
+    field_changes: z
+      .array(zCourseEditFieldChange)
+      .describe('**[READ-ONLY]** Course fields that differ between the live course and the draft.')
+      .readonly()
+      .optional(),
+    lessons_added: z
+      .number()
+      .int()
+      .describe('**[READ-ONLY]** Lessons the edit adds.')
+      .readonly()
+      .optional(),
+    lessons_removed: z
+      .number()
+      .int()
+      .describe('**[READ-ONLY]** Lessons the edit removes.')
+      .readonly()
+      .optional(),
+    lessons_modified: z
+      .number()
+      .int()
+      .describe('**[READ-ONLY]** Lessons the edit changes in place.')
+      .readonly()
+      .optional(),
+  })
+  .describe(
+    'What a pending edit would change if approved, so an admin can review the\ndecision without comparing two full course payloads by eye.\n'
+  );
+
+export const zApiResponseCourseEditDiff = z.object({
+  success: z.boolean().optional(),
+  data: zCourseEditDiff.optional(),
+  message: z.string().optional(),
+  error: z.unknown().optional(),
+});
+
+export const zPagedDtoCoursePendingEdit = z.object({
+  content: z.array(zCoursePendingEdit).optional(),
+  metadata: zPageMetadata.optional(),
+  links: zPageLinks.optional(),
+});
+
+export const zApiResponsePagedDtoCoursePendingEdit = z.object({
+  success: z.boolean().optional(),
+  data: zPagedDtoCoursePendingEdit.optional(),
   message: z.string().optional(),
   error: z.unknown().optional(),
 });
@@ -11126,6 +11417,13 @@ export const zStatusEnum14Writable = z
 export const zAssignmentTypeEnumWritable = z
   .enum(['global', 'organization'])
   .describe('Type of assignment - global or organization-specific');
+
+/**
+ * The decision to apply.
+ */
+export const zActionEnumWritable = z
+  .enum(['approved', 'rejected', 'revoked'])
+  .describe('The decision to apply.');
 
 /**
  * Domain/role to assign within the organisation
@@ -14038,6 +14336,44 @@ export const zCreateLinkData = z.object({
  */
 export const zCreateLinkResponse = zGuardianStudentLink;
 
+export const zSweepData = z.object({
+  body: z.never().optional(),
+  path: z.never().optional(),
+  query: z
+    .object({
+      deleteOrphans: z
+        .boolean()
+        .describe('Delete the orphaned files instead of only reporting them')
+        .optional()
+        .default(false),
+    })
+    .optional(),
+});
+
+/**
+ * OK
+ */
+export const zSweepResponse = zApiResponseSweepReport;
+
+export const zReconcileData = z.object({
+  body: z.never().optional(),
+  path: z.never().optional(),
+  query: z
+    .object({
+      prune: z
+        .boolean()
+        .describe('Clear domain references whose files no longer exist on disk')
+        .optional()
+        .default(false),
+    })
+    .optional(),
+});
+
+/**
+ * OK
+ */
+export const zReconcileResponse = zApiResponseReconcileReport;
+
 export const zEnrollStudentData = z.object({
   body: zEnrollmentRequest,
   path: z.never().optional(),
@@ -15241,6 +15577,23 @@ export const zCreateJobData = z.object({
  */
 export const zCreateJobResponse = zApiResponseClassMarketplaceJob;
 
+export const zUploadJobThumbnailData = z.object({
+  body: z
+    .object({
+      thumbnail: z.string(),
+    })
+    .optional(),
+  path: z.object({
+    uuid: z.string().uuid(),
+  }),
+  query: z.never().optional(),
+});
+
+/**
+ * OK
+ */
+export const zUploadJobThumbnailResponse = zApiResponseClassMarketplaceJob;
+
 export const zCancelJobData = z.object({
   body: z.never().optional(),
   path: z.object({
@@ -15670,14 +16023,11 @@ export const zCreateAdminUserData = z.object({
 export const zCreateAdminUserResponse = zApiResponseUser;
 
 export const zModerateProgramData = z.object({
-  body: z.never().optional(),
+  body: zContentModerationDecisionRequest,
   path: z.object({
-    uuid: z.string().uuid(),
+    uuid: z.string().uuid().describe('UUID of the training program'),
   }),
-  query: z.object({
-    action: z.string(),
-    reason: z.string().optional(),
-  }),
+  query: z.never().optional(),
 });
 
 /**
@@ -15823,18 +16173,15 @@ export const zActivateData = z.object({
 export const zActivateResponse = zApiResponseCurrency;
 
 export const zModerateCourseData = z.object({
-  body: z.never().optional(),
+  body: zContentModerationDecisionRequest,
   path: z.object({
-    uuid: z.string().uuid(),
+    uuid: z.string().uuid().describe('UUID of the course'),
   }),
-  query: z.object({
-    action: z.string(),
-    reason: z.string().optional(),
-  }),
+  query: z.never().optional(),
 });
 
 /**
- * OK
+ * Decision applied successfully
  */
 export const zModerateCourseResponse = zApiResponseCourse;
 
@@ -17215,6 +17562,19 @@ export const zGetMyStudentsData = z.object({
  */
 export const zGetMyStudentsResponse = zApiResponseListGuardianStudentSummaryDto;
 
+export const zGetFileData = z.object({
+  body: z.never().optional(),
+  path: z.object({
+    key: z.string().describe('Canonical storage key, e.g. course_thumbnails/uuid.jpg'),
+  }),
+  query: z.never().optional(),
+});
+
+/**
+ * File retrieved successfully
+ */
+export const zGetFileResponse = z.string().describe('File retrieved successfully');
+
 export const zCancelEnrollmentData = z.object({
   body: z.never().optional(),
   path: z.object({
@@ -17393,6 +17753,21 @@ export const zGetDefaultCurrencyData = z.object({
  */
 export const zGetDefaultCurrencyResponse = zApiResponseCurrency;
 
+export const zGetCourseVersionsData = z.object({
+  body: z.never().optional(),
+  path: z.object({
+    uuid: z.string().uuid().describe('UUID of the course'),
+  }),
+  query: z.object({
+    pageable: zPageable,
+  }),
+});
+
+/**
+ * Version history retrieved
+ */
+export const zGetCourseVersionsResponse = zApiResponsePagedDtoCourseVersionSnapshot;
+
 export const zGetStatusTransitionsData = z.object({
   body: z.never().optional(),
   path: z.object({
@@ -17405,6 +17780,32 @@ export const zGetStatusTransitionsData = z.object({
  * Available transitions retrieved successfully
  */
 export const zGetStatusTransitionsResponse = zApiResponseListContentStatus;
+
+export const zWithdrawPendingEditData = z.object({
+  body: z.never().optional(),
+  path: z.object({
+    uuid: z.string().uuid().describe('UUID of the course'),
+  }),
+  query: z.never().optional(),
+});
+
+/**
+ * Pending edit withdrawn
+ */
+export const zWithdrawPendingEditResponse = zApiResponseCoursePendingEdit;
+
+export const zGetPendingEditData = z.object({
+  body: z.never().optional(),
+  path: z.object({
+    uuid: z.string().uuid().describe('UUID of the course'),
+  }),
+  query: z.never().optional(),
+});
+
+/**
+ * Pending edit retrieved
+ */
+export const zGetPendingEditResponse = zApiResponseCoursePendingEdit;
 
 export const zCheckRubricAssociationData = z.object({
   body: z.never().optional(),
@@ -18617,6 +19018,19 @@ export const zGetDashboardActivityData = z.object({
  */
 export const zGetDashboardActivityResponse = zApiResponsePagedDtoAdminActivityEvent;
 
+export const zGetCourseEditDiffData = z.object({
+  body: z.never().optional(),
+  path: z.object({
+    uuid: z.string().uuid().describe('UUID of the live course'),
+  }),
+  query: z.never().optional(),
+});
+
+/**
+ * Diff retrieved
+ */
+export const zGetCourseEditDiffResponse = zApiResponseCourseEditDiff;
+
 export const zGetCourseModerationHistoryData = z.object({
   body: z.never().optional(),
   path: z.object({
@@ -18657,6 +19071,19 @@ export const zListPendingCoursesData = z.object({
  * OK
  */
 export const zListPendingCoursesResponse = zApiResponsePagedDtoCourse;
+
+export const zListPendingCourseEditsData = z.object({
+  body: z.never().optional(),
+  path: z.never().optional(),
+  query: z.object({
+    pageable: zPageable,
+  }),
+});
+
+/**
+ * Pending edits retrieved successfully
+ */
+export const zListPendingCourseEditsResponse = zApiResponsePagedDtoCoursePendingEdit;
 
 export const zClearInstructorAvailabilityData = z.object({
   body: z.never().optional(),

--- a/src/features/dashboard/student-assessment/useStudentAssignmentData.ts
+++ b/src/features/dashboard/student-assessment/useStudentAssignmentData.ts
@@ -149,10 +149,10 @@ export function getStudentAssignmentSubmissionState(row: StudentAssignmentRow) {
       label: dueSummary.label === 'Overdue' ? 'Overdue' : 'Pending',
       variant:
         dueSummary.tone === 'danger'
-          ? 'destructive'
+          ? ('destructive' as const)
           : dueSummary.tone === 'warning'
-            ? 'warning'
-            : 'secondary',
+            ? ('warning' as const)
+            : ('secondary' as const),
       helper:
         dueSummary.label === 'Overdue'
           ? 'Past due date'
@@ -164,7 +164,7 @@ export function getStudentAssignmentSubmissionState(row: StudentAssignmentRow) {
     return {
       key: "returned" as const,
       label: "Returned",
-      variant: "warning",
+      variant: "warning" as const,
       helper: "Requires revision and resubmission",
     };
   }
@@ -173,7 +173,7 @@ export function getStudentAssignmentSubmissionState(row: StudentAssignmentRow) {
     return {
       key: "graded" as const,
       label: "Graded",
-      variant: "success",
+      variant: "success" as const,
       helper:
         row.latestSubmission?.grade_display ??
         "Instructor feedback available",
@@ -183,7 +183,7 @@ export function getStudentAssignmentSubmissionState(row: StudentAssignmentRow) {
   return {
     key: 'submitted' as const,
     label: status === 'IN_REVIEW' ? 'In review' : 'Submitted',
-    variant: 'secondary',
+    variant: 'secondary' as const,
     helper: 'Submitted and awaiting grading',
   };
 }


### PR DESCRIPTION
## Summary

Companion to the backend draft-over-live re-approval work. Stops the UI from unpublishing a course on every edit, and adds the creator and admin surfaces for reviewing a pending edit.

## Changes

- **Fix the unpublish bug**: the course and branding forms no longer send `status: 'draft'` / `active: false` on edit — the change that pulled a published course off the catalogue whenever its creator edited it.
- **Creator**: a banner on the course builder showing that an edit is awaiting review and the course stays published, with a withdraw action.
- **Admin**: a "Pending edits" tab, a proposed-changes diff panel, and an edit-aware decision sidebar and reason sheet.
- Regenerate the API client for the new endpoints and the `moderate` request-body contract; update the course and program moderation call sites; fix type drift the regeneration exposed.

## Notes

Requires the backend PR to deploy first — the regenerated client expects the new `moderate` body contract. Biome and the brand-colour check pass on all changed files.